### PR TITLE
Flatten AI Developer Hub lab flow

### DIFF
--- a/labs/livelabs-ai-developer-hub/ai-developer-set-up-guide/introduction/images/ai-developer-setup-overview.svg
+++ b/labs/livelabs-ai-developer-hub/ai-developer-set-up-guide/introduction/images/ai-developer-setup-overview.svg
@@ -1,43 +1,58 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="520" viewBox="0 0 1200 520" role="img" aria-labelledby="title desc">
-  <title id="title">AI Developer setup path</title>
-  <desc id="desc">A three stage flow from Codex foundation to skill installation to running a LiveStack demo with Podman.</desc>
+  <title id="title">AI Developer Hub setup foundation</title>
+  <desc id="desc">Codex and skills form the required foundation for the workshop authoring labs, with an optional LiveStack demo available after setup.</desc>
   <rect width="1200" height="520" fill="#fbf9f7"/>
   <rect x="0" y="0" width="1200" height="12" fill="#c74634"/>
-  <text x="70" y="78" font-family="Arial, Helvetica, sans-serif" font-size="34" font-weight="700" fill="#312d2a">AI Developer Setup Guide</text>
-  <text x="70" y="114" font-family="Arial, Helvetica, sans-serif" font-size="18" fill="#5f5751">Install Codex, add reusable skills, then generate and run an Oracle-first LiveStack demo.</text>
+  <text x="70" y="76" font-family="Arial, Helvetica, sans-serif" font-size="34" font-weight="700" fill="#312d2a">AI Developer Hub Foundation</text>
+  <text x="70" y="112" font-family="Arial, Helvetica, sans-serif" font-size="18" fill="#5f5751">Set up Codex and reusable skills first. Then use them across the authoring labs; the LiveStack demo is optional.</text>
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#7a736e"/>
     </marker>
+    <marker id="arrow-teal" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#007d7e"/>
+    </marker>
   </defs>
   <g font-family="Arial, Helvetica, sans-serif">
-    <rect x="70" y="185" width="300" height="190" rx="0" fill="#fff" stroke="#d7d0c8" stroke-width="2"/>
-    <rect x="70" y="185" width="300" height="14" fill="#c74634"/>
-    <circle cx="112" cy="245" r="28" fill="#f6d7cf"/>
-    <text x="103" y="255" font-size="28" font-weight="700" fill="#c74634">1</text>
-    <text x="155" y="240" font-size="22" font-weight="700" fill="#312d2a">Codex foundation</text>
-    <text x="155" y="272" font-size="16" fill="#5f5751">Install Codex, sign in,</text>
-    <text x="155" y="296" font-size="16" fill="#5f5751">create the workspace,</text>
-    <text x="155" y="320" font-size="16" fill="#5f5751">and apply config.toml.</text>
-    <rect x="450" y="185" width="300" height="190" rx="0" fill="#fff" stroke="#d7d0c8" stroke-width="2"/>
-    <rect x="450" y="185" width="300" height="14" fill="#007d7e"/>
-    <circle cx="492" cy="245" r="28" fill="#dff3f0"/>
-    <text x="483" y="255" font-size="28" font-weight="700" fill="#007d7e">2</text>
-    <text x="535" y="240" font-size="22" font-weight="700" fill="#312d2a">Skills layer</text>
-    <text x="535" y="272" font-size="16" fill="#5f5751">Download skill zips,</text>
-    <text x="535" y="296" font-size="16" fill="#5f5751">install into skills,</text>
-    <text x="535" y="320" font-size="16" fill="#5f5751">restart, and test.</text>
-    <rect x="830" y="185" width="300" height="190" rx="0" fill="#fff" stroke="#d7d0c8" stroke-width="2"/>
-    <rect x="830" y="185" width="300" height="14" fill="#b25f00"/>
-    <circle cx="872" cy="245" r="28" fill="#faead2"/>
-    <text x="863" y="255" font-size="28" font-weight="700" fill="#b25f00">3</text>
-    <text x="915" y="240" font-size="22" font-weight="700" fill="#312d2a">Running demo</text>
-    <text x="915" y="272" font-size="16" fill="#5f5751">Use the orchestrator,</text>
-    <text x="915" y="296" font-size="16" fill="#5f5751">build with Compose,</text>
-    <text x="915" y="320" font-size="16" fill="#5f5751">open localhost:8505.</text>
-    <line x1="390" y1="280" x2="425" y2="280" stroke="#7a736e" stroke-width="3" marker-end="url(#arrow)"/>
-    <line x1="770" y1="280" x2="805" y2="280" stroke="#7a736e" stroke-width="3" marker-end="url(#arrow)"/>
-    <rect x="70" y="430" width="1060" height="46" fill="#312d2a"/>
-    <text x="95" y="460" font-size="17" fill="#fff">Checkpoint: install Codex, confirm skills load, and run a generated LiveStack locally.</text>
+    <rect x="70" y="170" width="285" height="170" rx="0" fill="#fff" stroke="#d7d0c8" stroke-width="2"/>
+    <rect x="70" y="170" width="285" height="14" fill="#c74634"/>
+    <circle cx="112" cy="228" r="28" fill="#f6d7cf"/>
+    <text x="103" y="238" font-size="28" font-weight="700" fill="#c74634">1</text>
+    <text x="155" y="222" font-size="22" font-weight="700" fill="#312d2a">Codex foundation</text>
+    <text x="155" y="254" font-size="16" fill="#5f5751">Install Codex, sign in,</text>
+    <text x="155" y="278" font-size="16" fill="#5f5751">create the workspace,</text>
+    <text x="155" y="302" font-size="16" fill="#5f5751">and apply config.toml.</text>
+
+    <line x1="375" y1="255" x2="430" y2="255" stroke="#7a736e" stroke-width="3" marker-end="url(#arrow)"/>
+
+    <rect x="455" y="170" width="285" height="170" rx="0" fill="#fff" stroke="#d7d0c8" stroke-width="2"/>
+    <rect x="455" y="170" width="285" height="14" fill="#007d7e"/>
+    <circle cx="497" cy="228" r="28" fill="#dff3f0"/>
+    <text x="488" y="238" font-size="28" font-weight="700" fill="#007d7e">2</text>
+    <text x="540" y="222" font-size="22" font-weight="700" fill="#312d2a">Skills layer</text>
+    <text x="540" y="254" font-size="16" fill="#5f5751">Install reusable skills,</text>
+    <text x="540" y="278" font-size="16" fill="#5f5751">restart Codex, and</text>
+    <text x="540" y="302" font-size="16" fill="#5f5751">confirm they load.</text>
+
+    <line x1="760" y1="230" x2="830" y2="210" stroke="#007d7e" stroke-width="3" marker-end="url(#arrow-teal)"/>
+    <line x1="760" y1="280" x2="830" y2="325" stroke="#7a736e" stroke-width="3" stroke-dasharray="8 7" marker-end="url(#arrow)"/>
+
+    <rect x="850" y="145" width="285" height="150" rx="0" fill="#fff" stroke="#d7d0c8" stroke-width="2"/>
+    <rect x="850" y="145" width="285" height="14" fill="#007d7e"/>
+    <circle cx="892" cy="202" r="28" fill="#dff3f0"/>
+    <text x="883" y="212" font-size="22" font-weight="700" fill="#007d7e">3+</text>
+    <text x="935" y="195" font-size="22" font-weight="700" fill="#312d2a">Authoring labs</text>
+    <text x="935" y="227" font-size="16" fill="#5f5751">Draft, capture images,</text>
+    <text x="935" y="251" font-size="16" fill="#5f5751">add quizzes, and adapt</text>
+    <text x="935" y="275" font-size="16" fill="#5f5751">content for outcomes.</text>
+
+    <rect x="850" y="335" width="285" height="105" rx="0" fill="#fffdf9" stroke="#b25f00" stroke-width="2" stroke-dasharray="8 6"/>
+    <rect x="850" y="335" width="285" height="12" fill="#b25f00"/>
+    <text x="875" y="378" font-size="20" font-weight="700" fill="#312d2a">Optional LiveStack demo</text>
+    <text x="875" y="407" font-size="16" fill="#5f5751">Generate and run a demo</text>
+    <text x="875" y="431" font-size="16" fill="#5f5751">after setup, if time allows.</text>
+
+    <rect x="70" y="455" width="1065" height="42" fill="#312d2a"/>
+    <text x="95" y="482" font-size="17" fill="#fff">Checkpoint: Codex and skills are ready. Continue into the authoring labs; run the demo only if time allows.</text>
   </g>
 </svg>

--- a/labs/livelabs-ai-developer-hub/ai-developer-set-up-guide/lab-3-orchestrate-and-run-livestack/lab-3-orchestrate-and-run-livestack.md
+++ b/labs/livelabs-ai-developer-hub/ai-developer-set-up-guide/lab-3-orchestrate-and-run-livestack/lab-3-orchestrate-and-run-livestack.md
@@ -1,4 +1,4 @@
-# Lab 3: Generate and Run a LiveStack Demo
+# Optional Lab: Generate and Run a LiveStack Demo
 
 ## Introduction
 
@@ -417,7 +417,7 @@ Use this task when the instructor gives you a completed LiveStack zip. Run it on
     - The generated README names a different Compose file or app port.
     - A bind-mounted folder needs the permissions described in the generated README.
 
-## Task 9: Complete the Lab 3 checkpoint
+## Task 9: Complete the optional demo checkpoint
 
 1. Confirm each item is true:
 

--- a/labs/livelabs-ai-developer-hub/introduction/introduction.md
+++ b/labs/livelabs-ai-developer-hub/introduction/introduction.md
@@ -1,42 +1,60 @@
 # Get Started with the LiveLabs AI Developer Hub
 
-Estimated Workshop Time: 25 minutes
+Estimated Workshop Time: 180 minutes
 
-The LiveLabs AI Developer Hub brings together agentic and automation-first workflows that help authors move faster without lowering quality. Instead of treating workshop development as a long chain of manual tasks, the hub shows how to use reusable tools to draft workshops from source material, capture screenshots, add knowledge checks, and adapt content for new audiences with far less repetition.
+The LiveLabs AI Developer Hub brings together agentic and automation-first workflows that help authors move faster without lowering quality. Instead of treating workshop development as a long chain of manual tasks, the hub shows how to set up Codex, install reusable skills, generate a LiveStack demo, draft workshops from source material, capture screenshots, add knowledge checks, and adapt content for new audiences with far less repetition.
 
-This matters because the real bottleneck in workshop delivery is rarely markdown alone. It is the surrounding work: planning, refactoring, image collection, QA cleanup, and keeping multiple versions aligned. The hub packages those workflows so authors can spend more time shaping outcomes and less time repeating setup steps.
+This matters because the real bottleneck in workshop delivery is rarely markdown alone. It is the surrounding work: planning, refactoring, image collection, QA cleanup, demo generation, and keeping multiple versions aligned. The hub packages those workflows so authors can spend more time shaping outcomes and less time repeating setup steps.
 
 ## Introduction
 
-This workshop introduces a set of practical workflows that help Oracle LiveLabs authors build, revise, and extend workshop content.
+This workshop starts by preparing an AI developer computer for Oracle LiveLabs work. You will install Codex, add reusable Oracle AI Developer skills, and verify that Codex can find those skills. After that foundation is in place, you can optionally use LiveStacks Orchestrator with Podman to generate and run a local Oracle-first demo or run a supplied zip on an OCI Compute instance when the instructor provides a prebuilt package.
 
-You will learn how to create workshops from source materials, capture workshop-ready screenshots, add quiz-based knowledge checks, and create industry-specific workshop variants.
+After the setup sequence, you will move through focused authoring examples that show how to create workshops from source materials, capture workshop-ready screenshots, add quiz-based knowledge checks, and create industry-specific workshop variants.
+
+The path is intentionally direct: Codex is the foundation, skills add repeatable workflows, and the remaining labs show how those capabilities accelerate common LiveLabs author tasks. The LiveStack demo is optional and appears after setup so you can try a generated application before continuing into the authoring labs.
+
+![AI Developer setup path](../ai-developer-set-up-guide/introduction/images/ai-developer-setup-overview.svg)
 
 **Download the latest packaged skills** and view supporting READ ME documents from the [LiveLabs AI Developer Skills Repository](https://oracle-my.sharepoint.com/:f:/p/kay_malcolm/IgBlxiOi-InZRbQHn6htgExAAZVgHtxSIwjAyAxRkmXa4ag?e=OuPt5u).
 
-In this workshop, you will move through a set of focused examples that show how to:
-
-- Turn an idea, blog post or product page into a draft LiveLabs workshop
-- Capture screenshots that match the exact workshop flow
-- Add quiz checks without rewriting the teaching content
-- Convert an existing workshop into an industry-specific variant while preserving fidelity
-
-The goal is to give LiveLabs authors practical workflows they can reuse across new workshops and revisions.
-
 ### Objectives
 
-- Understand how the LiveLabs AI Developer Hub supports common author workflows
-- Convert source material into a first-draft workshop with the authoring skill
-- Prepare workshop content so agentic tooling can work against stable targets
-- Capture screenshots that match the learner flow and workshop markdown
-- Add quiz checks at valid boundaries without changing the teaching flow
-- Review industry-converted workshops for fidelity, drift, and duplication
+In this workshop, you will:
+
+- Install and configure Codex for hands-on training work.
+- Install Codex skills from the shared Oracle skill bundle.
+- Verify that Codex can find and use the installed skills.
+- Install or verify Podman Desktop and Compose.
+- Optionally use LiveStacks Orchestrator to generate a demo from a business prompt.
+- Optionally build and run the generated stack locally.
+- Optionally install Podman on OCI Compute and run a supplied zip.
+- Convert source material into a first-draft workshop with the authoring skill.
+- Capture screenshots that match the learner flow and workshop markdown.
+- Add quiz checks at valid boundaries without changing the teaching flow.
+- Review industry-converted workshops for fidelity, drift, and duplication.
+
+## Lab outline
+
+- **Lab 1: Install and Configure Codex** - Install Codex Desktop, choose a workspace, apply the training config, and restart Codex.
+- **Lab 2: Install and Test Codex Skills** - Download skill zips from the shared Oracle folder, copy them into the Codex skills directory, restart Codex, and confirm the skills load.
+- **Optional Lab: Generate and Run a LiveStack Demo** - Optional stretch lab: install or verify Podman Desktop, use LiveStacks Orchestrator to generate a demo, build the stack, open the running app, and optionally run a supplied zip on OCI Compute.
+- **Lab 3: From Idea to Publish-Ready in One Flow** - Turn a source article into a draft LiveLabs workshop with a clear lab plan, validator-aligned markdown, and source-faithful learner tasks.
+- **Lab 4: Capture Workshop Images in Minutes** - Capture workshop screenshots, annotate key UI states, blur sensitive information, and keep image assets aligned with placeholder references.
+- **Lab 5: Add Knowledge Checks in Minutes** - Add quiz-based knowledge checks without rewriting the teaching content and validate the result.
+- **Lab 6: Turn Features into Customer Outcomes** - Create an industry-specific workshop variant, preserve source fidelity, and review the output for drift or duplication.
 
 ## Prerequisites
-In order to run codex skills successfully, participants must set up and install: VS Code, Git, Python 3, Node.js, and Codex (verify authentication via ChatGPT or API key). Additionally they must clone the LiveLabs repository to create workshops. 
-Detailed instructions are available as READ ME documents in the Hub's download folder.
 
->Note: AI-generated content should be reviewed carefully for accuracy, completeness, and alignment with Oracle & LiveLabs standards. While Codex can significantly accelerate development, it may produce incomplete or incorrect outputs. Authors are responsible for validating technical content, testing instructions, and ensuring overall quality before publishing
+- A macOS or Windows computer where you can install apps.
+- Optional: access to an OCI tenancy where you can create a VCN, public subnet, security rules, and Oracle Linux Compute VM.
+- Oracle network access and Oracle SSO for internal resources.
+- Access to the LiveLabs AI Developer skill bundle in the shared Oracle folder.
+- Enough free disk space for Podman Desktop, the Podman machine, and generated containers. Plan for about 35 GB free before creating the Podman machine.
+- A team-approved OpenAI or Oracle sign-in path for Codex. Do not paste API keys into shared files, screenshots, or workshop artifacts.
+- VS Code, Git, Python 3, Node.js, and a cloned LiveLabs repository for authoring and validation work.
+
+> **Note:** AI-generated content should be reviewed carefully for accuracy, completeness, and alignment with Oracle and LiveLabs standards. Codex can significantly accelerate development, but it may produce incomplete or incorrect outputs. Authors are responsible for validating technical content, testing instructions, and ensuring overall quality before publishing.
 
 ## Learn More
 
@@ -46,4 +64,4 @@ Detailed instructions are available as READ ME documents in the Hub's download f
 ## Acknowledgements
 
 * **Author** - Linda Foinding, Principal Product Manager, Outbound Database Product Management
-* **Last Updated By/Date** - Linda Foinding, April 2026
+* **Last Updated By/Date** - Linda Foinding, May 2026

--- a/labs/livelabs-ai-developer-hub/workshops/sandbox/manifest.json
+++ b/labs/livelabs-ai-developer-hub/workshops/sandbox/manifest.json
@@ -4,31 +4,41 @@
   "tutorials": [
     {
       "title": "Introduction",
-      "description": "Overview of the LiveLabs playground workshop and the author workflows it packages for workshop creation, screenshots, quiz checks, and industry conversion.",
+      "description": "Overview of the LiveLabs AI Developer Hub, including setup, Codex skills, optional LiveStacks demo generation, and author workflow labs.",
       "filename": "./../../introduction/introduction.md"
     },
     {
-      "title": "Lab 1: AI Developer Setup Guide",
-      "description": "Install and configure Codex, add Oracle AI Developer skills, and use LiveStacks Orchestrator with Podman to generate and run a local demo.",
-      "filename": "./../../ai-developer-set-up-guide/introduction/introduction.md"
+      "title": "Lab 1: Install and Configure Codex",
+      "description": "Install Codex, choose a workspace, apply config.toml, and restart Codex.",
+      "filename": "./../../ai-developer-set-up-guide/lab-1-codex-installation/lab-1-codex-installation.md"
     },
     {
-      "title": "Lab 2: From Idea to Publish-Ready in One Flow",
+      "title": "Lab 2: Install and Test Codex Skills",
+      "description": "Install skills from the shared Oracle bundle and confirm Codex can load them.",
+      "filename": "./../../ai-developer-set-up-guide/lab-2-install-codex-skills/lab-2-install-codex-skills.md"
+    },
+    {
+      "title": "Optional Lab: Generate and Run a LiveStack Demo",
+      "description": "Optional stretch lab: use LiveStacks Orchestrator and Podman Compose to generate and run a local demo, or run a supplied solution zip on OCI Compute.",
+      "filename": "./../../ai-developer-set-up-guide/lab-3-orchestrate-and-run-livestack/lab-3-orchestrate-and-run-livestack.md"
+    },
+    {
+      "title": "Lab 3: From Idea to Publish-Ready in One Flow",
       "description": "Turn a source article into a draft LiveLabs workshop with a clear lab plan, validator-aligned markdown, and source-faithful learner tasks.",
       "filename": "./../../from-idea-to-publish-ready/from-idea-to-publish-ready.md"
     },
     {
-      "title": "Lab 3: Capture Workshop Images in Minute",
+      "title": "Lab 4: Capture Workshop Images in Minutes",
       "description": "Capture workshop screenshots, annotate key UI states, blur sensitive information, and keep image assets aligned with placeholder references.",
       "filename": "./../../capture-workshop-images-in-minutes/capture-workshop-images-in-minutes.md"
     },
     {
-      "title": "Lab 4: Add Knowledge Checks in Minutes",
+      "title": "Lab 5: Add Knowledge Checks in Minutes",
       "description": "Add quiz-based knowledge checks without rewriting the teaching content and validate the result.",
       "filename": "./../../add-knowledge-checks-in-minutes/add-knowledge-checks-in-minutes.md"
     },
     {
-      "title": "Lab 5: Turn Features into Customer Outcomes",
+      "title": "Lab 6: Turn Features into Customer Outcomes",
       "description": "Create an industry-specific workshop variant, preserve source fidelity, and review the output for drift or duplication.",
       "filename": "./../../turn-features-into-customer-outcomes/turn-features-into-customer-outcomes.md"
     }


### PR DESCRIPTION
## Summary
- Flattened the AI Developer Hub flow so Codex setup and skill installation are the required foundation.
- Moved the LiveStack demo after Lab 2 and marked it as optional.
- Updated the top-level introduction, lab outline, parent manifest, optional demo lab title, and setup graphic.

## Files or components touched
- labs/livelabs-ai-developer-hub/introduction/introduction.md
- labs/livelabs-ai-developer-hub/workshops/sandbox/manifest.json
- labs/livelabs-ai-developer-hub/ai-developer-set-up-guide/lab-3-orchestrate-and-run-livestack/lab-3-orchestrate-and-run-livestack.md
- labs/livelabs-ai-developer-hub/ai-developer-set-up-guide/introduction/images/ai-developer-setup-overview.svg

## Validation
- Verified all manifest targets resolve locally.
- Ran the LiveLabs markdown validator across the affected workshop labs: Validation PASSED, Errors: 0.
- Parsed the updated SVG as valid XML.

## Notes or risks
- Unrelated local changes outside labs/livelabs-ai-developer-hub were not staged or committed.
