### PR TITLE
Share Polly context automatically for trusted developers

### DIFF
--- a/polly/.codex-plugin/plugin.json
+++ b/polly/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "polly",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Shared, canonical-repository memory for developer-owned Codex sessions.",
   "author": {
     "name": "Oracle LiveLabs"
@@ -9,7 +9,7 @@
   "interface": {
     "displayName": "Polly",
     "shortDescription": "Share trusted coding context across forks.",
-    "longDescription": "Polly retrieves scoped project memory at session and prompt boundaries, then records private rolling checkpoints without blocking Codex when Polly is unavailable.",
+    "longDescription": "Polly retrieves scoped project memory at session and prompt boundaries, then records authenticated rolling shared checkpoints without blocking Codex when Polly is unavailable.",
     "developerName": "Oracle LiveLabs",
     "category": "Productivity",
     "capabilities": ["Hooks", "Secure credentials", "Shared memory"],

--- a/polly/README.md
+++ b/polly/README.md
@@ -1,6 +1,6 @@
 # Polly Codex Plugin
 
-Polly shares reviewed coding context across developers and forks while keeping each developer's private continuity isolated. The plugin retrieves bounded context on `SessionStart` and `UserPromptSubmit`, then updates one rolling private checkpoint per Codex session on `Stop`.
+Polly shares authenticated developer context across developers and forks while preserving explicitly private memory. The plugin retrieves bounded context on `SessionStart` and `UserPromptSubmit`, then updates one rolling shared checkpoint per Codex session on `Stop`.
 
 ## Prerequisites
 
@@ -9,6 +9,15 @@ Polly shares reviewed coding context across developers and forks while keeping e
 - macOS Keychain, Linux Secret Service with `secret-tool`, or Windows DPAPI.
 - A one-time enrollment code issued by the Polly administrator.
 
+## Install
+
+```bash
+codex plugin marketplace add oracle-livelabs/common --ref main
+codex plugin add polly@oracle-livelabs-common
+```
+
+Start a new Codex thread after installation. Codex reads the plugin manifest's `skills` path, discovers `skills/polly-setup/SKILL.md`, and exposes its declared name as `$polly-setup`.
+
 
 ## Workflow
 
@@ -16,7 +25,7 @@ Polly shares reviewed coding context across developers and forks while keeping e
 2. The developer runs `$polly-setup`. The permanent token is stored by the operating system and is never written to a plaintext file.
 3. In a fork clone, the developer runs `$polly-init` with the upstream project, for example `oracle-livelabs/livestack`.
 4. Codex hooks retrieve personal continuity plus accepted shared memory under that canonical repository.
-5. Stop hooks replace one private checkpoint for the current session. They do not end the session or publish every turn.
-6. `$polly-share` creates a proposed record. An administrator must accept it before other developers receive it as trusted shared context.
+5. Stop hooks replace one shared checkpoint for the current session. Collaborators receive the latest progress without accumulating one record per turn.
+6. `$polly-share` immediately publishes a deliberate decision, constraint, assumption, blocker, or progress note to collaborators. The administrator can revoke developers or moderate incorrect records, but no approval queue is required.
 
 If Polly is unavailable, every hook fails open so Codex continues without injected context.

--- a/polly/hooks/hooks.json
+++ b/polly/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Retrieve scoped Polly context and maintain rolling private checkpoints.",
+  "description": "Retrieve scoped Polly context and maintain rolling shared checkpoints.",
   "hooks": {
     "SessionStart": [
       {

--- a/polly/scripts/polly_bridge.py
+++ b/polly/scripts/polly_bridge.py
@@ -675,8 +675,8 @@ def handle_hook(hook: dict[str, Any]) -> dict[str, Any]:
                 "turn_id": turn_id,
                 "event_type": "codex_stop",
                 "record_type": "progress",
-                "scope": "agent_thread",
-                "visibility": "private",
+                "scope": "branch_task",
+                "visibility": "shared",
                 "confidence": 0.75,
                 "content": content,
             }
@@ -779,13 +779,13 @@ def cmd_share(args: argparse.Namespace) -> int:
             "event_type": "manual_share",
             "record_type": args.record_type,
             "scope": args.scope,
-            "visibility": "proposed_shared",
+            "visibility": "shared",
             "confidence": args.confidence,
             "content": args.content,
         }
     )
     result = api_request(server, "/agent/events", payload=payload, token=token)
-    print(f"Proposed Polly memory {result['id']} for administrator review.")
+    print(f"Shared Polly memory {result['id']} with collaborators.")
     return 0
 
 
@@ -808,7 +808,7 @@ def build_parser() -> argparse.ArgumentParser:
     status.add_argument("--repo", default=".")
     status.set_defaults(func=cmd_status)
 
-    share = sub.add_parser("share", help="Propose a memory for administrator review")
+    share = sub.add_parser("share", help="Share a memory with collaborators")
     share.add_argument("--repo", default=".")
     share.add_argument("--content", required=True)
     share.add_argument("--record-type", default="decision")

--- a/polly/skills/polly-share/SKILL.md
+++ b/polly/skills/polly-share/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: polly-share
-description: Propose a coding decision, constraint, assumption, blocker, or progress note for shared Polly memory. Use when the user explicitly wants collaborators to receive a piece of project context.
+description: Share a coding decision, constraint, assumption, blocker, or progress note with collaborators through Polly. Use when the user explicitly wants collaborators to receive a durable piece of project context.
 ---
 
 # Polly Share
 
-Share only the specific project fact the user intends to propose. Run from the relevant repository:
+Share only the specific project fact the user intends to publish. Run from the relevant repository:
 
 ```bash
 python3 "$PLUGIN_ROOT/scripts/polly_bridge.py" share \
@@ -14,4 +14,4 @@ python3 "$PLUGIN_ROOT/scripts/polly_bridge.py" share \
   --content "Use the canonical upstream repository as the collaboration namespace."
 ```
 
-Valid record types include `decision`, `constraint`, `assumption`, `open_question`, `progress`, and `blocker`. The result is `proposed_shared`; it is not accepted team truth until an administrator reviews it.
+Valid record types include `decision`, `constraint`, `assumption`, `open_question`, `progress`, and `blocker`. Approved developers publish directly to accepted shared memory; administrators retain moderation and developer-revocation controls.

--- a/polly/tests/test_bridge.py
+++ b/polly/tests/test_bridge.py
@@ -5,6 +5,7 @@ import json
 import os
 import subprocess
 import sys
+from argparse import Namespace
 from pathlib import Path
 
 import pytest
@@ -104,6 +105,71 @@ def test_hook_event_ids_are_stable() -> None:
     assert bridge.hook_event_id(hook, "same turn") != bridge.hook_event_id(
         hook, "different turn"
     )
+
+
+def test_stop_hook_publishes_one_rolling_shared_checkpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = make_repo(tmp_path)
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        bridge, "configured_identity", lambda: ("http://polly", "dev-a", "token")
+    )
+
+    def capture_request(_server, path, *, payload=None, token=None):
+        captured.update(path=path, payload=payload, token=token)
+        return {"id": "mem-stop"}
+
+    monkeypatch.setattr(bridge, "api_request", capture_request)
+    result = bridge.handle_hook(
+        {
+            "session_id": "session-1",
+            "hook_event_name": "Stop",
+            "cwd": str(repo),
+            "last_assistant_message": "Implemented the repository resolver.",
+        }
+    )
+
+    assert result == {"continue": True}
+    assert captured["path"] == "/agent/events"
+    payload = captured["payload"]
+    assert isinstance(payload, dict)
+    assert payload["event_type"] == "codex_stop"
+    assert payload["scope"] == "branch_task"
+    assert payload["visibility"] == "shared"
+
+
+def test_manual_share_publishes_directly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo = make_repo(tmp_path)
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        bridge, "configured_identity", lambda: ("http://polly", "dev-a", "token")
+    )
+
+    def capture_request(_server, path, *, payload=None, token=None):
+        captured.update(path=path, payload=payload, token=token)
+        return {"id": "mem-share"}
+
+    monkeypatch.setattr(bridge, "api_request", capture_request)
+    result = bridge.cmd_share(
+        Namespace(
+            repo=str(repo),
+            session_id="manual-session",
+            event_id="manual-event",
+            record_type="decision",
+            scope="repo_shared",
+            confidence=0.9,
+            content="Use canonical repository memory.",
+        )
+    )
+
+    assert result == 0
+    payload = captured["payload"]
+    assert isinstance(payload, dict)
+    assert payload["visibility"] == "shared"
+    assert "with collaborators" in capsys.readouterr().out
 
 
 def test_hook_fails_open_without_enrollment(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- publish rolling Stop checkpoints directly as accepted shared context
- publish explicit polly-share records without an administrator approval queue
- retain explicit private memory, moderation, and developer revocation
- document how Codex discovers polly-setup from the plugin skill manifest
- bump the plugin to 0.2.0 to avoid stale cache reuse

## Verification

- 12 plugin tests passed
- Ruff passed
- plugin and hook JSON validated
- git diff check passed