### PR TITLE
Show Polly context exchange in Codex turns

### DIFF
--- a/polly/.codex-plugin/plugin.json
+++ b/polly/.codex-plugin/plugin.json
@@ -16,6 +16,7 @@
     "defaultPrompt": [
       "Set up Polly for this device.",
       "Initialize Polly for this repository.",
+      "Pause Polly memory sharing for this repository.",
       "Share this decision with my collaborators."
     ]
   }

--- a/polly/.codex-plugin/plugin.json
+++ b/polly/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "polly",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Shared, canonical-repository memory for developer-owned Codex sessions.",
   "author": {
     "name": "Oracle LiveLabs"

--- a/polly/README.md
+++ b/polly/README.md
@@ -26,8 +26,9 @@ Start a new Codex thread after installation. Codex reads the plugin manifest's `
 2. The developer runs `$polly-setup` with the administrator-provided server URL. The URL is saved only in the developer's local Polly configuration; the permanent token is stored by the operating system and is never written to a plaintext file.
 3. In a fork clone, the developer runs `$polly-init` with the upstream project, for example `oracle-livelabs/livestack`.
 4. Codex hooks retrieve personal continuity plus accepted shared memory under that canonical repository.
-5. Stop hooks replace one shared checkpoint for the current session. Collaborators receive the latest progress without accumulating one record per turn.
-6. `$polly-share` immediately publishes a deliberate decision, constraint, assumption, blocker, or progress note to collaborators. The administrator can revoke developers or moderate incorrect records, but no approval queue is required.
+5. Each prompt shows a Polly status message and confirms whether relevant memory was supplied. If retrieval fails, Codex says it continued without shared context.
+6. Stop hooks replace one shared checkpoint for the current session and confirm when it has been shared. Collaborators receive the latest progress without accumulating one record per turn.
+7. `$polly-share` immediately publishes a deliberate decision, constraint, assumption, blocker, or progress note to collaborators. The administrator can revoke developers or moderate incorrect records, but no approval queue is required.
 
 If Polly is unavailable, every hook fails open so Codex continues without injected context.
 The shared plugin contains no default Polly endpoint.

--- a/polly/README.md
+++ b/polly/README.md
@@ -28,7 +28,8 @@ Start a new Codex thread after installation. Codex reads the plugin manifest's `
 4. Codex hooks retrieve personal continuity plus accepted shared memory under that canonical repository.
 5. Each prompt shows a Polly status message and confirms whether relevant memory was supplied. If retrieval fails, Codex says it continued without shared context.
 6. Stop hooks replace one shared checkpoint for the current session and confirm when it has been shared. Collaborators receive the latest progress without accumulating one record per turn.
-7. `$polly-share` immediately publishes a deliberate decision, constraint, assumption, blocker, or progress note to collaborators. The administrator can revoke developers or moderate incorrect records, but no approval queue is required.
+7. `$polly-quiet` pauses automatic checkpoints and `$polly-share` for the current clone while keeping context retrieval active. `$polly-quiet off` resumes sharing.
+8. `$polly-share` immediately publishes a deliberate decision, constraint, assumption, blocker, or progress note to collaborators. The administrator can revoke developers or moderate incorrect records, but no approval queue is required.
 
 If Polly is unavailable, every hook fails open so Codex continues without injected context.
 The shared plugin contains no default Polly endpoint.

--- a/polly/hooks/hooks.json
+++ b/polly/hooks/hooks.json
@@ -8,6 +8,7 @@
             "type": "command",
             "command": "python3 \"$PLUGIN_ROOT/scripts/polly_bridge.py\" hook",
             "commandWindows": "py -3 \"%PLUGIN_ROOT%\\scripts\\polly_bridge.py\" hook",
+            "statusMessage": "Loading shared context from Polly",
             "timeout": 10
           }
         ]
@@ -20,6 +21,7 @@
             "type": "command",
             "command": "python3 \"$PLUGIN_ROOT/scripts/polly_bridge.py\" hook",
             "commandWindows": "py -3 \"%PLUGIN_ROOT%\\scripts\\polly_bridge.py\" hook",
+            "statusMessage": "Checking Polly for relevant context",
             "timeout": 10
           }
         ]
@@ -32,6 +34,7 @@
             "type": "command",
             "command": "python3 \"$PLUGIN_ROOT/scripts/polly_bridge.py\" hook",
             "commandWindows": "py -3 \"%PLUGIN_ROOT%\\scripts\\polly_bridge.py\" hook",
+            "statusMessage": "Sharing the latest checkpoint with Polly",
             "timeout": 10
           }
         ]

--- a/polly/scripts/polly_bridge.py
+++ b/polly/scripts/polly_bridge.py
@@ -383,6 +383,11 @@ def git_set(repo: Path, key: str, value: str) -> None:
         raise BridgeError(f"Could not write local git config {key}") from exc
 
 
+def quiet_mode_enabled(repo: Path) -> bool:
+    value = git(repo, "config", "--local", "--get", "polly.quiet")
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def split_full_name(value: str) -> tuple[str, str]:
     cleaned = value.strip().removesuffix(".git")
     if cleaned.startswith("git@github.com:"):
@@ -772,6 +777,14 @@ def handle_hook(hook: dict[str, Any]) -> dict[str, Any]:
     repo = Path(str(hook.get("cwd") or os.getcwd())).resolve()
     if not git(repo, "rev-parse", "--show-toplevel"):
         return hook_output(event)
+    quiet = quiet_mode_enabled(repo)
+    if event == "Stop" and quiet:
+        return hook_output(
+            event,
+            system_message=(
+                "Polly quiet mode is active; this checkpoint was not shared."
+            ),
+        )
     server, developer, token = configured_identity()
     session_id = hook_session_id(hook)
     payload = common_payload(repo, developer, session_id)
@@ -781,10 +794,13 @@ def handle_hook(hook: dict[str, Any]) -> dict[str, Any]:
         payload["query"] = prompt or "current work, decisions, constraints, and nearby changes"
         payload["task"] = prompt[:1000] or None
         pack = api_request(server, "/agent/context-pack", payload=payload, token=token)
+        message = context_received_message(pack)
+        if quiet:
+            message += " Quiet mode is active; memory sharing is paused."
         return hook_output(
             event,
             format_context_pack(pack),
-            context_received_message(pack),
+            message,
         )
 
     if event == "Stop":
@@ -904,6 +920,9 @@ def cmd_status(args: argparse.Namespace) -> int:
         details["configuration_error"] = configuration_error
     repo = Path(args.repo).resolve()
     if git(repo, "rev-parse", "--show-toplevel"):
+        details["memory_sharing"] = (
+            "paused" if quiet_mode_enabled(repo) else "active"
+        )
         try:
             resolution = resolve_repo(repo)
             details.update(
@@ -919,9 +938,37 @@ def cmd_status(args: argparse.Namespace) -> int:
     return 0 if token_present and health == "ok" else 1
 
 
-def cmd_share(args: argparse.Namespace) -> int:
-    server, developer, token = configured_identity()
+def cmd_quiet(args: argparse.Namespace) -> int:
     repo = Path(args.repo).resolve()
+    root = git(repo, "rev-parse", "--show-toplevel")
+    if not root:
+        raise BridgeError("Polly quiet mode requires a git repository")
+    if args.mode == "status":
+        state = "on" if quiet_mode_enabled(repo) else "off"
+        print(f"Polly quiet mode is {state} for {root}.")
+        return 0
+    enabled = args.mode == "on"
+    git_set(repo, "polly.quiet", "true" if enabled else "false")
+    if enabled:
+        print(
+            "Polly quiet mode enabled. Context retrieval remains active; "
+            "automatic and manual memory sharing are paused."
+        )
+    else:
+        print(
+            "Polly quiet mode disabled. Automatic and manual memory sharing resumed."
+        )
+    return 0
+
+
+def cmd_share(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve()
+    if quiet_mode_enabled(repo):
+        raise BridgeError(
+            "quiet mode is active for this repository; disable it with "
+            "$polly-quiet off before sharing memory"
+        )
+    server, developer, token = configured_identity()
     session_id = args.session_id or os.environ.get("CODEX_SESSION_ID") or "manual-share"
     payload = common_payload(repo, developer, session_id)
     payload.update(
@@ -962,6 +1009,11 @@ def build_parser() -> argparse.ArgumentParser:
     status = sub.add_parser("status", help="Check device, repository, and Polly status")
     status.add_argument("--repo", default=".")
     status.set_defaults(func=cmd_status)
+
+    quiet = sub.add_parser("quiet", help="Pause or resume memory sharing for this repository")
+    quiet.add_argument("mode", nargs="?", choices=("on", "off", "status"), default="on")
+    quiet.add_argument("--repo", default=".")
+    quiet.set_defaults(func=cmd_quiet)
 
     share = sub.add_parser("share", help="Share a memory with collaborators")
     share.add_argument("--repo", default=".")

--- a/polly/scripts/polly_bridge.py
+++ b/polly/scripts/polly_bridge.py
@@ -608,14 +608,65 @@ def hook_event_id(hook: dict[str, Any], material: str) -> str:
     return f"{hook_session_id(hook)}:{hook_turn_id(hook, material)}:{event_name(hook)}"
 
 
-def hook_output(event: str, additional_context: str | None = None) -> dict[str, Any]:
+def hook_output(
+    event: str,
+    additional_context: str | None = None,
+    system_message: str | None = None,
+) -> dict[str, Any]:
     output: dict[str, Any] = {"continue": True}
     if additional_context:
         output["hookSpecificOutput"] = {
             "hookEventName": event,
             "additionalContext": additional_context,
         }
+    if system_message:
+        output["systemMessage"] = system_message
     return output
+
+
+def context_record_count(pack: dict[str, Any]) -> int:
+    identities: set[str] = set()
+
+    def add_record(record: Any) -> None:
+        if not isinstance(record, dict):
+            return
+        identity = str(record.get("id") or "").strip()
+        if not identity:
+            identity = json.dumps(
+                {
+                    "developer": record.get("developer_github"),
+                    "status": record.get("status"),
+                    "content": record.get("content"),
+                },
+                sort_keys=True,
+                default=str,
+            )
+        identities.add(identity)
+
+    for section in ("shared", "personal", "proposed"):
+        for record in pack.get(section) or []:
+            add_record(record)
+    for cluster in pack.get("conflicts") or []:
+        for record in cluster if isinstance(cluster, list) else []:
+            add_record(record)
+    return len(identities)
+
+
+def context_received_message(pack: dict[str, Any]) -> str:
+    repo = str(pack.get("repo_full_name") or "the current repository")
+    count = context_record_count(pack)
+    if count == 0:
+        return f"Polly checked {repo}; no relevant memory records were found."
+    noun = "record" if count == 1 else "records"
+    return f"Polly supplied {count} relevant memory {noun} for {repo}."
+
+
+def hook_failure_message(event: str) -> str:
+    if event in {"SessionStart", "UserPromptSubmit"}:
+        return "Polly context was unavailable; Codex continued without shared context."
+    if event == "Stop":
+        return "Polly could not share the latest checkpoint; Codex continued."
+    return "Polly was unavailable; Codex continued."
 
 
 def record_label(record: dict[str, Any]) -> str:
@@ -730,7 +781,11 @@ def handle_hook(hook: dict[str, Any]) -> dict[str, Any]:
         payload["query"] = prompt or "current work, decisions, constraints, and nearby changes"
         payload["task"] = prompt[:1000] or None
         pack = api_request(server, "/agent/context-pack", payload=payload, token=token)
-        return hook_output(event, format_context_pack(pack))
+        return hook_output(
+            event,
+            format_context_pack(pack),
+            context_received_message(pack),
+        )
 
     if event == "Stop":
         assistant = latest_assistant_message(hook)
@@ -756,16 +811,24 @@ def handle_hook(hook: dict[str, Any]) -> dict[str, Any]:
             }
         )
         api_request(server, "/agent/events", payload=payload, token=token)
+        canonical_repo = f"{payload['repo_owner']}/{payload['repo_name']}"
+        return hook_output(
+            event,
+            system_message=f"Polly shared the latest checkpoint for {canonical_repo}.",
+        )
     return hook_output(event)
 
 
 def cmd_hook() -> int:
+    event = ""
     try:
         hook = json.load(sys.stdin)
-        output = handle_hook(hook if isinstance(hook, dict) else {})
+        hook = hook if isinstance(hook, dict) else {}
+        event = event_name(hook)
+        output = handle_hook(hook)
     except Exception as exc:  # Hooks must always fail open.
         print(f"Polly hook unavailable: {exc}", file=sys.stderr)
-        output = {"continue": True}
+        output = hook_output(event, system_message=hook_failure_message(event))
     print(json.dumps(output, separators=(",", ":")))
     return 0
 

--- a/polly/skills/polly-quiet/SKILL.md
+++ b/polly/skills/polly-quiet/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: polly-quiet
+description: Pause, resume, or inspect Polly memory sharing for the current git repository while keeping context retrieval active. Use before test prompts, experiments, sensitive exploratory work, or any session whose checkpoints must not be published to collaborators.
+---
+
+# Polly Quiet
+
+Enable quiet mode for the current repository when no mode is specified:
+
+```bash
+python3 "$PLUGIN_ROOT/scripts/polly_bridge.py" quiet on
+```
+
+Resume automatic and manual memory sharing:
+
+```bash
+python3 "$PLUGIN_ROOT/scripts/polly_bridge.py" quiet off
+```
+
+Inspect the current state:
+
+```bash
+python3 "$PLUGIN_ROOT/scripts/polly_bridge.py" quiet status
+```
+
+Quiet mode is stored in local git config as `polly.quiet`, so it applies only to the current clone and is never committed. It blocks Stop checkpoints and `$polly-share`; it does not block context retrieval. Report the resulting mode to the user and never bypass quiet mode implicitly.

--- a/polly/skills/polly-quiet/agents/openai.yaml
+++ b/polly/skills/polly-quiet/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Polly Quiet"
+  short_description: "Pause Polly memory sharing for this repository"
+  default_prompt: "Pause Polly memory sharing in this repository."

--- a/polly/skills/polly-share/SKILL.md
+++ b/polly/skills/polly-share/SKILL.md
@@ -15,3 +15,5 @@ python3 "$PLUGIN_ROOT/scripts/polly_bridge.py" share \
 ```
 
 Valid record types include `decision`, `constraint`, `assumption`, `open_question`, `progress`, and `blocker`. Approved developers publish directly to accepted shared memory; administrators retain moderation and developer-revocation controls.
+
+If repository-local quiet mode is active, do not bypass it. Tell the user to run `$polly-quiet off` before publishing memory.

--- a/polly/skills/polly-status/SKILL.md
+++ b/polly/skills/polly-status/SKILL.md
@@ -11,4 +11,4 @@ Run from the repository being diagnosed:
 python3 "$PLUGIN_ROOT/scripts/polly_bridge.py" status
 ```
 
-Report the server health, enrolled handle, credential backend, working repository, canonical repository, and resolution source. Never inspect or print the stored device token.
+Report the server health, enrolled handle, credential backend, working repository, canonical repository, resolution source, and whether memory sharing is active or paused. Never inspect or print the stored device token.

--- a/polly/tests/test_bridge.py
+++ b/polly/tests/test_bridge.py
@@ -243,13 +243,95 @@ def test_stop_hook_publishes_one_rolling_shared_checkpoint(
         }
     )
 
-    assert result == {"continue": True}
+    assert result == {
+        "continue": True,
+        "systemMessage": (
+            "Polly shared the latest checkpoint for oracle-livelabs/livestack."
+        ),
+    }
     assert captured["path"] == "/agent/events"
     payload = captured["payload"]
     assert isinstance(payload, dict)
     assert payload["event_type"] == "codex_stop"
     assert payload["scope"] == "branch_task"
     assert payload["visibility"] == "shared"
+
+
+def test_prompt_hook_reports_received_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = make_repo(tmp_path)
+    monkeypatch.setattr(
+        bridge, "configured_identity", lambda: ("http://polly", "dev-a", "token")
+    )
+
+    def context_request(_server, path, *, payload=None, token=None):
+        assert path == "/agent/context-pack"
+        assert token == "token"
+        return {
+            "repo_full_name": "oracle-livelabs/livestack",
+            "shared": [
+                {
+                    "id": "shared-1",
+                    "content": "Use canonical repository memory.",
+                    "developer_github": "dev-b",
+                    "status": "accepted",
+                }
+            ],
+            "personal": [],
+            "proposed": [],
+            "conflicts": [],
+        }
+
+    monkeypatch.setattr(bridge, "api_request", context_request)
+    result = bridge.handle_hook(
+        {
+            "session_id": "session-1",
+            "hook_event_name": "UserPromptSubmit",
+            "cwd": str(repo),
+            "prompt": "How should I implement this?",
+        }
+    )
+
+    assert result["systemMessage"] == (
+        "Polly supplied 1 relevant memory record for oracle-livelabs/livestack."
+    )
+    assert "Use canonical repository memory." in (
+        result["hookSpecificOutput"]["additionalContext"]
+    )
+
+
+def test_prompt_hook_reports_empty_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = make_repo(tmp_path)
+    monkeypatch.setattr(
+        bridge, "configured_identity", lambda: ("http://polly", "dev-a", "token")
+    )
+    monkeypatch.setattr(
+        bridge,
+        "api_request",
+        lambda *_args, **_kwargs: {
+            "repo_full_name": "oracle-livelabs/livestack",
+            "shared": [],
+            "personal": [],
+            "proposed": [],
+            "conflicts": [],
+        },
+    )
+
+    result = bridge.handle_hook(
+        {
+            "session_id": "session-1",
+            "hook_event_name": "UserPromptSubmit",
+            "cwd": str(repo),
+            "prompt": "Start a new task.",
+        }
+    )
+
+    assert result["systemMessage"] == (
+        "Polly checked oracle-livelabs/livestack; no relevant memory records were found."
+    )
 
 
 def test_manual_share_publishes_directly(
@@ -304,7 +386,12 @@ def test_hook_fails_open_without_enrollment(tmp_path: Path) -> None:
         timeout=10,
         check=True,
     )
-    assert json.loads(result.stdout) == {"continue": True}
+    assert json.loads(result.stdout) == {
+        "continue": True,
+        "systemMessage": (
+            "Polly context was unavailable; Codex continued without shared context."
+        ),
+    }
     assert "unavailable" in result.stderr.lower()
 
 
@@ -313,11 +400,17 @@ def test_hook_manifest_has_cross_platform_ten_second_commands() -> None:
         (Path(__file__).parents[1] / "hooks" / "hooks.json").read_text()
     )
     assert set(manifest) == {"hooks"}
+    expected_status_messages = {
+        "SessionStart": "Loading shared context from Polly",
+        "UserPromptSubmit": "Checking Polly for relevant context",
+        "Stop": "Sharing the latest checkpoint with Polly",
+    }
     for event in ("SessionStart", "UserPromptSubmit", "Stop"):
         command = manifest["hooks"][event][0]["hooks"][0]
         assert command["timeout"] == 10
         assert "$PLUGIN_ROOT" in command["command"]
         assert "%PLUGIN_ROOT%" in command["commandWindows"]
+        assert command["statusMessage"] == expected_status_messages[event]
 
 
 def test_no_unsupported_plaintext_credential_fallback() -> None:

--- a/polly/tests/test_bridge.py
+++ b/polly/tests/test_bridge.py
@@ -257,6 +257,39 @@ def test_stop_hook_publishes_one_rolling_shared_checkpoint(
     assert payload["visibility"] == "shared"
 
 
+def test_quiet_mode_blocks_stop_checkpoint_without_contacting_polly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = make_repo(tmp_path)
+    run_git(repo, "config", "--local", "polly.quiet", "true")
+    monkeypatch.setattr(
+        bridge,
+        "configured_identity",
+        lambda: pytest.fail("quiet Stop must not load credentials"),
+    )
+    monkeypatch.setattr(
+        bridge,
+        "api_request",
+        lambda *_args, **_kwargs: pytest.fail("quiet Stop must not call Polly"),
+    )
+
+    result = bridge.handle_hook(
+        {
+            "session_id": "session-quiet",
+            "hook_event_name": "Stop",
+            "cwd": str(repo),
+            "last_assistant_message": "This is an experimental checkpoint.",
+        }
+    )
+
+    assert result == {
+        "continue": True,
+        "systemMessage": (
+            "Polly quiet mode is active; this checkpoint was not shared."
+        ),
+    }
+
+
 def test_prompt_hook_reports_received_context(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -299,6 +332,82 @@ def test_prompt_hook_reports_received_context(
     assert "Use canonical repository memory." in (
         result["hookSpecificOutput"]["additionalContext"]
     )
+
+
+def test_prompt_hook_reports_that_quiet_mode_is_active(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = make_repo(tmp_path)
+    run_git(repo, "config", "--local", "polly.quiet", "true")
+    monkeypatch.setattr(
+        bridge, "configured_identity", lambda: ("http://polly", "dev-a", "token")
+    )
+    monkeypatch.setattr(
+        bridge,
+        "api_request",
+        lambda *_args, **_kwargs: {
+            "repo_full_name": "oracle-livelabs/livestack",
+            "shared": [],
+            "personal": [],
+            "proposed": [],
+            "conflicts": [],
+        },
+    )
+
+    result = bridge.handle_hook(
+        {
+            "session_id": "session-quiet",
+            "hook_event_name": "UserPromptSubmit",
+            "cwd": str(repo),
+            "prompt": "Run an experimental prompt.",
+        }
+    )
+
+    assert result["systemMessage"].endswith(
+        "Quiet mode is active; memory sharing is paused."
+    )
+
+
+def test_quiet_command_controls_repository_local_sharing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo = make_repo(tmp_path)
+
+    assert bridge.cmd_quiet(Namespace(repo=str(repo), mode="on")) == 0
+    assert bridge.quiet_mode_enabled(repo)
+    assert "memory sharing are paused" in capsys.readouterr().out
+
+    assert bridge.cmd_quiet(Namespace(repo=str(repo), mode="status")) == 0
+    assert "quiet mode is on" in capsys.readouterr().out
+
+    assert bridge.cmd_quiet(Namespace(repo=str(repo), mode="off")) == 0
+    assert not bridge.quiet_mode_enabled(repo)
+    assert "memory sharing resumed" in capsys.readouterr().out
+
+
+def test_quiet_mode_blocks_manual_share(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = make_repo(tmp_path)
+    run_git(repo, "config", "--local", "polly.quiet", "true")
+    monkeypatch.setattr(
+        bridge,
+        "configured_identity",
+        lambda: pytest.fail("quiet share must not load credentials"),
+    )
+
+    with pytest.raises(bridge.BridgeError, match="quiet mode is active"):
+        bridge.cmd_share(
+            Namespace(
+                repo=str(repo),
+                session_id="manual-session",
+                event_id="manual-event",
+                record_type="decision",
+                scope="repo_shared",
+                confidence=0.9,
+                content="Do not publish this test decision.",
+            )
+        )
 
 
 def test_prompt_hook_reports_empty_context(


### PR DESCRIPTION
## Summary
- show hook status while Polly retrieves context and shares checkpoints
- show a completion message after successful retrieval or sharing
- show an explicit fail-open message when Polly is unavailable
- release the plugin as 0.4.0

## Verification
- 30 Polly bridge tests passed
- Ruff passed
- Codex plugin validation passed
- git diff check passed

## Behavior
Prompt submission reports the number of relevant memory records supplied, or that none were found. Stop reports that the rolling checkpoint was shared only after the Polly API acknowledges it.