### PR TITLE
Use sparse checkout for Polly marketplace installs

### DIFF
--- a/polly/README.md
+++ b/polly/README.md
@@ -13,11 +13,27 @@ Polly shares authenticated developer context across developers and forks while p
 ## Install
 
 ```bash
-codex plugin marketplace add oracle-livelabs/common --ref main
+codex plugin marketplace add oracle-livelabs/common --ref main \
+  --sparse .agents/plugins \
+  --sparse polly
 codex plugin add polly@oracle-livelabs-common
 ```
 
-Start a new Codex thread after installation. Codex reads the plugin manifest's `skills` path, discovers `skills/polly-setup/SKILL.md`, and exposes its declared name as `$polly-setup`.
+The sparse paths keep Codex from cloning the full `common` repository. Existing
+installations that were registered without sparse checkout can be migrated in
+place without re-enrolling:
+
+```bash
+codex plugin marketplace remove oracle-livelabs-common
+codex plugin marketplace add oracle-livelabs/common --ref main \
+  --sparse .agents/plugins \
+  --sparse polly
+codex plugin list --marketplace oracle-livelabs-common
+```
+
+Restart Codex and start a new thread after installing or refreshing the plugin.
+Codex reads the plugin manifest's `skills` path, discovers
+`skills/polly-setup/SKILL.md`, and exposes its declared name as `$polly-setup`.
 
 
 ## Workflow


### PR DESCRIPTION
## Summary

- register the `common` marketplace with sparse paths for `.agents/plugins` and `polly`
- document an in-place migration for existing full-clone installations
- require a Codex restart and new thread after refresh

## Why

A full `common` marketplace checkout is about 2.1 GB and can exceed Codex's 30-second clone timeout. The tested sparse checkout is about 2.5 MB and installs Polly 0.4.0 successfully.

## Verification

- isolated `codex plugin marketplace add` with both sparse paths
- isolated `codex plugin add polly@oracle-livelabs-common`
- Polly plugin validator
- `git diff --check`
