### PR TITLE
Add session-independent private Polly memory

### DIFF
--- a/polly/.codex-plugin/plugin.json
+++ b/polly/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "polly",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Shared, canonical-repository memory for developer-owned Codex sessions.",
   "author": {
     "name": "Oracle LiveLabs"
@@ -9,14 +9,15 @@
   "interface": {
     "displayName": "Polly",
     "shortDescription": "Share trusted coding context across forks.",
-    "longDescription": "Polly retrieves scoped project memory at session and prompt boundaries, then records authenticated rolling shared checkpoints without blocking Codex when Polly is unavailable.",
+    "longDescription": "Polly retrieves scoped project memory at session and prompt boundaries, records authenticated rolling shared checkpoints, and saves explicit private continuity notes without blocking Codex when Polly is unavailable.",
     "developerName": "Oracle LiveLabs",
     "category": "Productivity",
-    "capabilities": ["Hooks", "Secure credentials", "Shared memory"],
+    "capabilities": ["Hooks", "Secure credentials", "Shared memory", "Private memory"],
     "defaultPrompt": [
       "Set up Polly for this device.",
       "Initialize Polly for this repository.",
-      "Pause Polly memory sharing for this repository.",
+      "Pause Polly memory writes for this repository.",
+      "Remember this note privately across my future sessions.",
       "Share this decision with my collaborators."
     ]
   }

--- a/polly/README.md
+++ b/polly/README.md
@@ -44,8 +44,9 @@ Codex reads the plugin manifest's `skills` path, discovers
 4. Codex hooks retrieve personal continuity plus accepted shared memory under that canonical repository.
 5. Each prompt shows a Polly status message and confirms whether relevant memory was supplied. If retrieval fails, Codex says it continued without shared context.
 6. Stop hooks replace one shared checkpoint for the current session and confirm when it has been shared. Collaborators receive the latest progress without accumulating one record per turn.
-7. `$polly-quiet` pauses automatic checkpoints and `$polly-share` for the current clone while keeping context retrieval active. `$polly-quiet off` resumes sharing.
-8. `$polly-share` immediately publishes a deliberate decision, constraint, assumption, blocker, or progress note to collaborators. The administrator can revoke developers or moderate incorrect records, but no approval queue is required.
+7. `$polly-quiet` pauses automatic checkpoints, `$polly-share`, and `$polly-private` for the current clone while keeping context retrieval active. `$polly-quiet off` resumes memory writes.
+8. `$polly-private` saves a deliberate developer-only note under the canonical repository without tying it to the current Codex session. It is available as personal continuity in future sessions but is never returned to collaborators.
+9. `$polly-share` immediately publishes a deliberate decision, constraint, assumption, blocker, or progress note to collaborators. The administrator can revoke developers or moderate incorrect records, but no approval queue is required.
 
 If Polly is unavailable, every hook fails open so Codex continues without injected context.
 The shared plugin contains no default Polly endpoint.

--- a/polly/scripts/polly_bridge.py
+++ b/polly/scripts/polly_bridge.py
@@ -573,7 +573,7 @@ def configured_identity() -> tuple[str, str, str]:
     return server, developer, token
 
 
-def common_payload(repo: Path, developer: str, session_id: str) -> dict[str, Any]:
+def common_payload(repo: Path, developer: str, session_id: str | None) -> dict[str, Any]:
     resolution = resolve_repo(repo)
     return {
         **git_context(repo),
@@ -954,11 +954,11 @@ def cmd_quiet(args: argparse.Namespace) -> int:
     if enabled:
         print(
             "Polly quiet mode enabled. Context retrieval remains active; "
-            "automatic and manual memory sharing are paused."
+            "automatic and manual memory writes are paused."
         )
     else:
         print(
-            "Polly quiet mode disabled. Automatic and manual memory sharing resumed."
+            "Polly quiet mode disabled. Automatic and manual memory writes resumed."
         )
     return 0
 
@@ -986,6 +986,32 @@ def cmd_share(args: argparse.Namespace) -> int:
     )
     result = api_request(server, "/agent/events", payload=payload, token=token)
     print(f"Shared Polly memory {result['id']} with collaborators.")
+    return 0
+
+
+def cmd_private(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve()
+    if quiet_mode_enabled(repo):
+        raise BridgeError(
+            "quiet mode is active for this repository; disable it with "
+            "$polly-quiet off before saving private memory"
+        )
+    server, developer, token = configured_identity()
+    payload = common_payload(repo, developer, None)
+    payload["branch"] = None
+    payload.update(
+        {
+            "event_id": args.event_id,
+            "event_type": "manual_private",
+            "record_type": args.record_type,
+            "scope": "developer_private",
+            "visibility": "private",
+            "confidence": args.confidence,
+            "content": args.content,
+        }
+    )
+    result = api_request(server, "/agent/events", payload=payload, token=token)
+    print(f"Saved private Polly memory {result['id']} for your future sessions.")
     return 0
 
 
@@ -1026,6 +1052,16 @@ def build_parser() -> argparse.ArgumentParser:
     share.add_argument("--session-id")
     share.add_argument("--event-id")
     share.set_defaults(func=cmd_share)
+
+    private = sub.add_parser(
+        "private", help="Save durable private memory for future sessions"
+    )
+    private.add_argument("--repo", default=".")
+    private.add_argument("--content", required=True)
+    private.add_argument("--record-type", default="observation")
+    private.add_argument("--confidence", type=float, default=0.8)
+    private.add_argument("--event-id")
+    private.set_defaults(func=cmd_private)
 
     sub.add_parser("hook", help=argparse.SUPPRESS).set_defaults(func=lambda _args: cmd_hook())
     return parser

--- a/polly/skills/polly-private/SKILL.md
+++ b/polly/skills/polly-private/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: polly-private
+description: Save a durable developer-only project memory in Polly without tying it to the current Codex session or sharing it with collaborators. Use when the user wants a personal decision, hypothesis, reminder, preference, or continuity note available in future sessions for the same canonical repository.
+---
+
+# Polly Private
+
+Save only the specific project fact the user wants Polly to remember privately. Run from the relevant repository:
+
+```bash
+python3 "$PLUGIN_ROOT/scripts/polly_bridge.py" private \
+  --record-type observation \
+  --content "Prefer the local mock server when debugging this repository."
+```
+
+Choose `decision`, `constraint`, `assumption`, `open_question`, `progress`, `blocker`, or `observation` as the record type. The bridge fixes the scope to `developer_private`, omits the Codex session ID, and stores the record only for the enrolled developer under the canonical repository.
+
+Do not store credentials, tokens, or other secrets. Polly private memory is isolated from collaborators during retrieval, but Polly administrators can inspect database records.
+
+If repository-local quiet mode is active, do not bypass it. Tell the user to run `$polly-quiet off` before saving memory. Report the returned memory ID and state that it will be available only to the requesting developer in future sessions for the same canonical repository.

--- a/polly/skills/polly-private/agents/openai.yaml
+++ b/polly/skills/polly-private/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Polly Private"
+  short_description: "Save private repository memory across sessions"
+  default_prompt: "Use $polly-private to remember this note only for my future Codex sessions."

--- a/polly/skills/polly-quiet/SKILL.md
+++ b/polly/skills/polly-quiet/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: polly-quiet
-description: Pause, resume, or inspect Polly memory sharing for the current git repository while keeping context retrieval active. Use before test prompts, experiments, sensitive exploratory work, or any session whose checkpoints must not be published to collaborators.
+description: Pause, resume, or inspect Polly memory writes for the current git repository while keeping context retrieval active. Use before test prompts, experiments, sensitive exploratory work, or any session whose checkpoints and manual memories must not be stored.
 ---
 
 # Polly Quiet
@@ -11,7 +11,7 @@ Enable quiet mode for the current repository when no mode is specified:
 python3 "$PLUGIN_ROOT/scripts/polly_bridge.py" quiet on
 ```
 
-Resume automatic and manual memory sharing:
+Resume automatic and manual memory writes:
 
 ```bash
 python3 "$PLUGIN_ROOT/scripts/polly_bridge.py" quiet off
@@ -23,4 +23,4 @@ Inspect the current state:
 python3 "$PLUGIN_ROOT/scripts/polly_bridge.py" quiet status
 ```
 
-Quiet mode is stored in local git config as `polly.quiet`, so it applies only to the current clone and is never committed. It blocks Stop checkpoints and `$polly-share`; it does not block context retrieval. Report the resulting mode to the user and never bypass quiet mode implicitly.
+Quiet mode is stored in local git config as `polly.quiet`, so it applies only to the current clone and is never committed. It blocks Stop checkpoints, `$polly-share`, and `$polly-private`; it does not block context retrieval. Report the resulting mode to the user and never bypass quiet mode implicitly.

--- a/polly/skills/polly-quiet/agents/openai.yaml
+++ b/polly/skills/polly-quiet/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Polly Quiet"
-  short_description: "Pause Polly memory sharing for this repository"
-  default_prompt: "Pause Polly memory sharing in this repository."
+  short_description: "Pause Polly memory writes for this repository"
+  default_prompt: "Use $polly-quiet to pause Polly memory writes in this repository."

--- a/polly/tests/test_bridge.py
+++ b/polly/tests/test_bridge.py
@@ -393,14 +393,14 @@ def test_quiet_command_controls_repository_local_sharing(
 
     assert bridge.cmd_quiet(Namespace(repo=str(repo), mode="on")) == 0
     assert bridge.quiet_mode_enabled(repo)
-    assert "memory sharing are paused" in capsys.readouterr().out
+    assert "memory writes are paused" in capsys.readouterr().out
 
     assert bridge.cmd_quiet(Namespace(repo=str(repo), mode="status")) == 0
     assert "quiet mode is on" in capsys.readouterr().out
 
     assert bridge.cmd_quiet(Namespace(repo=str(repo), mode="off")) == 0
     assert not bridge.quiet_mode_enabled(repo)
-    assert "memory sharing resumed" in capsys.readouterr().out
+    assert "memory writes resumed" in capsys.readouterr().out
 
 
 def test_quiet_mode_blocks_manual_share(
@@ -424,6 +424,29 @@ def test_quiet_mode_blocks_manual_share(
                 scope="repo_shared",
                 confidence=0.9,
                 content="Do not publish this test decision.",
+            )
+        )
+
+
+def test_quiet_mode_blocks_private_memory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = make_repo(tmp_path)
+    run_git(repo, "config", "--local", "polly.quiet", "true")
+    monkeypatch.setattr(
+        bridge,
+        "configured_identity",
+        lambda: pytest.fail("quiet private memory must not load credentials"),
+    )
+
+    with pytest.raises(bridge.BridgeError, match="quiet mode is active"):
+        bridge.cmd_private(
+            Namespace(
+                repo=str(repo),
+                event_id="private-event",
+                record_type="observation",
+                confidence=0.9,
+                content="Do not store this private test note.",
             )
         )
 
@@ -492,6 +515,51 @@ def test_manual_share_publishes_directly(
     assert isinstance(payload, dict)
     assert payload["visibility"] == "shared"
     assert "with collaborators" in capsys.readouterr().out
+
+
+def test_private_memory_is_session_independent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = make_repo(tmp_path)
+    run_git(
+        repo,
+        "config",
+        "--local",
+        "polly.canonicalRepo",
+        "oracle-livelabs/livestack",
+    )
+    captured: dict[str, object] = {}
+    monkeypatch.setenv("CODEX_SESSION_ID", "active-codex-session")
+    monkeypatch.setattr(
+        bridge, "configured_identity", lambda: ("http://polly", "dev-a", "token")
+    )
+
+    def capture_request(_server, path, *, payload=None, token=None):
+        captured.update(path=path, payload=payload, token=token)
+        return {"id": "mem-private"}
+
+    monkeypatch.setattr(bridge, "api_request", capture_request)
+    result = bridge.cmd_private(
+        Namespace(
+            repo=str(repo),
+            event_id="private-event",
+            record_type="observation",
+            confidence=0.9,
+            content="Remember my preferred local debugging workflow.",
+        )
+    )
+
+    assert result == 0
+    payload = captured["payload"]
+    assert isinstance(payload, dict)
+    assert payload["session_id"] is None
+    assert payload["branch"] is None
+    assert payload["scope"] == "developer_private"
+    assert payload["visibility"] == "private"
+    assert payload["event_type"] == "manual_private"
+    assert "future sessions" in capsys.readouterr().out
 
 
 def test_hook_fails_open_without_enrollment(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add `$polly-private` for explicit developer-only repository memory
- omit session and branch bindings so notes remain useful across future Codex sessions
- keep canonical-repository isolation and make `$polly-quiet` block private writes
- release the Polly plugin as version 0.5.0

## Validation
- 37 bridge tests passed
- 5 server memory-broker isolation tests passed
- Ruff checks passed
- skill and plugin validators passed

## Notes
- Private notes are never returned to collaborators, but remain visible to Polly administrators.
- No Polly server deployment is required; the existing private-memory API and index path already support this payload.