### PR TITLE
Update new author guide status graph

### DIFF
--- a/new-author-guide/assets/css/author-guide-improvements.css
+++ b/new-author-guide/assets/css/author-guide-improvements.css
@@ -3321,59 +3321,210 @@ body.author-nav-closed #app[data-redwood-creator-pass="2026-05-25"] .author-glob
   pointer-events: none;
 }
 
-#app[data-redwood-creator-pass="2026-05-25"] .wms-status-flow {
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-graph {
   display: grid;
-  gap: 1rem;
-}
-
-#app[data-redwood-creator-pass="2026-05-25"] .wms-status-csv {
-  display: none;
-}
-
-#app[data-redwood-creator-pass="2026-05-25"] .wms-status-buttons {
-  display: grid;
-  grid-template-columns: repeat(7, minmax(0, 1fr));
-  gap: 0.5rem;
-}
-
-#app[data-redwood-creator-pass="2026-05-25"] .wms-status-button {
-  min-height: 3.2rem;
-  padding: 0.55rem 0.55rem;
-  border: 1px solid rgba(104, 96, 91, 0.28);
+  overflow: hidden;
+  border: 1px solid rgba(212, 207, 202, 0.92);
   border-radius: 8px;
   background: #fff;
-  color: var(--ink);
-  font-size: 0.78rem;
-  font-weight: 800;
-  line-height: 1.2;
-  text-align: center;
 }
 
-#app[data-redwood-creator-pass="2026-05-25"] .wms-status-button:hover,
-#app[data-redwood-creator-pass="2026-05-25"] .wms-status-button:focus-visible,
-#app[data-redwood-creator-pass="2026-05-25"] .wms-status-button.is-active {
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-graph-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+  padding: 0.8rem;
+  border-bottom: 1px solid rgba(212, 207, 202, 0.82);
+  background: #fbf9f8;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-legend,
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-legend-pill,
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-action {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2rem;
+  border: 1px solid rgba(104, 96, 91, 0.24);
+  border-radius: 999px;
+  background: #fff;
+  color: var(--ink-soft);
+  font-size: 0.72rem;
+  font-weight: 800;
+  line-height: 1.1;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-legend-pill {
+  gap: 0.45rem;
+  padding: 0.35rem 0.65rem;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-action {
+  padding: 0.35rem 0.7rem;
+  cursor: pointer;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-action:hover,
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-action:focus-visible {
   border-color: rgba(199, 70, 52, 0.46);
   background: #fff8f7;
   color: var(--rose);
 }
 
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-legend-pill::before {
+  content: "";
+  width: 1.6rem;
+  height: 0;
+  border-top: 3px solid #7c8794;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-legend-pill.is-return-path::before {
+  border-top-style: dashed;
+  border-top-color: #a16207;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-legend-pill.is-selected::before {
+  width: 0.8rem;
+  height: 0.8rem;
+  border: 3px solid var(--ink);
+  border-radius: 4px;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-graph-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(17rem, 20rem);
+  min-height: 34rem;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-graph-stage {
+  overflow: hidden;
+  border-right: 1px solid rgba(212, 207, 202, 0.82);
+  background:
+    linear-gradient(#eef2f7 1px, transparent 1px),
+    linear-gradient(90deg, #eef2f7 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-svg {
+  display: block;
+  width: 100%;
+  height: clamp(24rem, 43vw, 34rem);
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-node rect {
+  stroke: rgba(56, 52, 49, 0.72);
+  stroke-width: 1.2;
+  cursor: pointer;
+  filter: drop-shadow(0 7px 10px rgba(56, 52, 49, 0.12));
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-node text {
+  fill: var(--ink);
+  font-size: 12.5px;
+  font-weight: 850;
+  pointer-events: none;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-node .wms-status-node-subtext {
+  fill: var(--ink-soft);
+  font-size: 10.5px;
+  font-weight: 750;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-node.is-selected rect {
+  stroke: var(--ink);
+  stroke-width: 4;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-node:focus-visible rect {
+  stroke: var(--rose);
+  stroke-width: 4;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-edge {
+  fill: none;
+  stroke: #7c8794;
+  stroke-width: 2.5;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-edge.is-return-path {
+  stroke: #a16207;
+  stroke-dasharray: 8 6;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-edge.is-selected {
+  stroke-width: 3.5;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-node.is-dimmed,
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-edge.is-dimmed,
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-edge-label-bg.is-dimmed,
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-edge-label.is-dimmed {
+  opacity: 0.2;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-edge-label-bg {
+  fill: rgba(255, 255, 255, 0.96);
+  stroke: rgba(212, 207, 202, 0.9);
+  stroke-width: 1;
+  pointer-events: none;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-edge-label {
+  fill: var(--ink-soft);
+  font-size: 11px;
+  font-weight: 800;
+  paint-order: stroke;
+  stroke: #fff;
+  stroke-linejoin: round;
+  stroke-width: 2px;
+  pointer-events: none;
+}
+
 #app[data-redwood-creator-pass="2026-05-25"] .wms-status-detail {
+  display: grid;
+  align-content: start;
+  gap: 0.95rem;
   padding: 1rem;
-  border: 1px solid rgba(212, 207, 202, 0.92);
-  border-radius: 8px;
   background: #fbf9f8;
 }
 
 #app[data-redwood-creator-pass="2026-05-25"] .wms-status-detail h4 {
-  margin: 0.25rem 0 0.4rem;
-  font-size: 1.1rem;
+  margin: 0.25rem 0 0;
+  font-size: 1.14rem;
   font-weight: 850;
 }
 
-#app[data-redwood-creator-pass="2026-05-25"] .wms-status-detail p {
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-detail-block {
+  display: grid;
+  gap: 0.35rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid rgba(212, 207, 202, 0.78);
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-detail-block strong {
+  color: var(--ink);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-detail p,
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-detail li {
   margin: 0;
   color: var(--ink-soft);
-  line-height: 1.55;
+  font-size: 0.84rem;
+  line-height: 1.48;
+}
+
+#app[data-redwood-creator-pass="2026-05-25"] .wms-status-detail ul {
+  margin: 0;
+  padding-left: 1rem;
 }
 
 #app[data-redwood-creator-pass="2026-05-25"] .install-card-grid {
@@ -3529,9 +3680,23 @@ body.author-nav-closed #app[data-redwood-creator-pass="2026-05-25"] .author-glob
     grid-template-columns: 1fr;
   }
 
-  #app[data-redwood-creator-pass="2026-05-25"] .wms-status-buttons,
   #app[data-redwood-creator-pass="2026-05-25"] .install-card-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  #app[data-redwood-creator-pass="2026-05-25"] .wms-status-graph-toolbar,
+  #app[data-redwood-creator-pass="2026-05-25"] .wms-status-graph-layout {
+    grid-template-columns: 1fr;
+  }
+
+  #app[data-redwood-creator-pass="2026-05-25"] .wms-status-graph-toolbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  #app[data-redwood-creator-pass="2026-05-25"] .wms-status-graph-stage {
+    border-right: 0;
+    border-bottom: 1px solid rgba(212, 207, 202, 0.82);
   }
 
   #app[data-redwood-creator-pass="2026-05-25"] .preview-checkpoint-layout {
@@ -3549,9 +3714,20 @@ body.author-nav-closed #app[data-redwood-creator-pass="2026-05-25"] .author-glob
     gap: 0.2rem;
   }
 
-  #app[data-redwood-creator-pass="2026-05-25"] .wms-status-buttons,
   #app[data-redwood-creator-pass="2026-05-25"] .install-card-grid {
     grid-template-columns: 1fr;
+  }
+
+  #app[data-redwood-creator-pass="2026-05-25"] .wms-status-actions,
+  #app[data-redwood-creator-pass="2026-05-25"] .wms-status-legend {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    width: 100%;
+  }
+
+  #app[data-redwood-creator-pass="2026-05-25"] .wms-status-action,
+  #app[data-redwood-creator-pass="2026-05-25"] .wms-status-legend-pill {
+    justify-content: center;
   }
 
 }

--- a/new-author-guide/assets/js/author-guide-app.js
+++ b/new-author-guide/assets/js/author-guide-app.js
@@ -177,6 +177,182 @@
       leads: "production"
     }
   ];
+  var wmsStatusGraphViewBox = { x: 0, y: 0, width: 1320, height: 660 };
+  var wmsStatusNodeHalfWidth = 82;
+  var wmsStatusNodeHalfHeight = 31;
+  var wmsStatusGraphFitGutter = 24;
+  var wmsStatusGraphStatuses = [
+    {
+      id: "submitted",
+      label: "Submitted",
+      group: "Intake",
+      responsible: "Workshop author / submitter",
+      meaning: "The workshop has been submitted for initial review. The author has provided the first set of workshop details and is waiting for review.",
+      nextStep: "The reviewer validates whether the submitted information is sufficient. If it is complete, the workshop moves to Approved. If it is incomplete, it moves to More Info Needed.",
+      checks: [
+        "Workshop details are present.",
+        "Workshop purpose and audience are clear.",
+        "Required owner or contact information is available."
+      ],
+      x: 110,
+      y: 300,
+      color: "#f3f4f6"
+    },
+    {
+      id: "more-info",
+      label: "More Info Needed",
+      group: "Rework",
+      responsible: "Workshop author / submitter",
+      meaning: "The reviewer needs clarifications or missing details before the workshop can continue.",
+      nextStep: "The author updates the requested information and resubmits the workshop for review.",
+      checks: [
+        "Respond to reviewer comments.",
+        "Add missing metadata, scope, owner, or setup details.",
+        "Confirm the resubmitted information is complete."
+      ],
+      x: 300,
+      y: 155,
+      color: "#fff7ed"
+    },
+    {
+      id: "approved",
+      label: "Approved",
+      group: "Approval",
+      responsible: "LiveLabs reviewer / approver",
+      meaning: "The workshop request has enough information and is approved to move into the build or development stage.",
+      nextStep: "The author or workshop development owner starts the content build in In Development.",
+      checks: [
+        "Submission is understandable and actionable.",
+        "Workshop can proceed to content development.",
+        "Any approval notes are communicated to the author."
+      ],
+      x: 300,
+      y: 300,
+      color: "#ecfdf5"
+    },
+    {
+      id: "in-development",
+      label: "In Development",
+      group: "Build",
+      responsible: "Workshop author / development owner",
+      meaning: "The workshop content is being created or updated. This can include labs, Markdown content, images, manifests, setup steps, and validation work.",
+      nextStep: "When development is ready, the author moves the workshop to Self QA.",
+      checks: [
+        "Lab Markdown content is written or updated.",
+        "Images, manifests, and folder structure are in place.",
+        "Commands and code examples are ready to test.",
+        "Links and references are prepared for validation."
+      ],
+      x: 510,
+      y: 300,
+      color: "#eff6ff"
+    },
+    {
+      id: "self-qa",
+      label: "Self QA",
+      group: "QA",
+      responsible: "Workshop author / content owner",
+      meaning: "The author performs their own quality checks before marking the workshop as complete.",
+      nextStep: "If self-QA passes, move to Self QA Complete. If issues are found, return to In Development for fixes.",
+      checks: [
+        "Information in the workshop is adequate and updated.",
+        "Code is correct and working.",
+        "Links are correct.",
+        "Help email is included in manifest.json.",
+        "WMS URLs are updated as needed after approval.",
+        "Filenames are descriptive and lowercase.",
+        "Folder structure follows the sample workshop structure.",
+        "Images include useful alt text."
+      ],
+      x: 720,
+      y: 300,
+      color: "#f5f3ff"
+    },
+    {
+      id: "self-qa-complete",
+      label: "Self QA Complete",
+      group: "QA",
+      responsible: "Workshop author / content owner",
+      meaning: "The author has completed self-QA and confirmed that the workshop is ready to be marked complete or move forward in the publication workflow.",
+      nextStep: "Move the workshop to Completed.",
+      checks: [
+        "Self-QA checklist is complete.",
+        "No known blocking issues remain.",
+        "The workshop owner is ready to complete the workflow."
+      ],
+      x: 950,
+      y: 300,
+      color: "#eef2ff"
+    },
+    {
+      id: "completed",
+      label: "Completed",
+      group: "Done",
+      responsible: "LiveLabs owner / workshop owner",
+      meaning: "The workshop is complete and available for normal use, publication, or maintenance depending on your internal workflow.",
+      nextStep: "No immediate action is required. Later, the workshop may enter Quarterly QA or return to In Development if updates are required.",
+      checks: [
+        "Workshop is complete.",
+        "Ownership is clear for future maintenance.",
+        "Future QA or update cycle can be scheduled."
+      ],
+      x: 1180,
+      y: 300,
+      color: "#f0fdf4"
+    },
+    {
+      id: "quarterly-qa",
+      label: "Quarterly QA",
+      group: "Recurring QA",
+      responsible: "QA reviewer / workshop owner",
+      meaning: "The completed workshop is reviewed during a periodic QA cycle to make sure it is still accurate and working.",
+      nextStep: "If QA passes, move to Quarterly QA Complete. If problems are found, return to In Development for fixes.",
+      checks: [
+        "Workshop information is still accurate and updated.",
+        "Code and commands still work.",
+        "Links still resolve correctly.",
+        "Manifest and support contact details are still current.",
+        "Screenshots and instructions still match the product experience."
+      ],
+      x: 950,
+      y: 480,
+      color: "#fffbeb"
+    },
+    {
+      id: "quarterly-qa-complete",
+      label: "Quarterly QA Complete",
+      group: "Done",
+      responsible: "QA reviewer / LiveLabs owner",
+      meaning: "The scheduled QA review is complete and no blocking issues remain from that review cycle.",
+      nextStep: "Return the workshop to Completed until the next review cycle or update request.",
+      checks: [
+        "Quarterly QA review is complete.",
+        "Findings are resolved or documented.",
+        "Workshop can return to normal completed status."
+      ],
+      x: 1180,
+      y: 480,
+      color: "#f0fdf4"
+    }
+  ];
+  var wmsStatusGraphTransitions = [
+    { from: "submitted", to: "approved", type: "normal", label: "review passes", labelX: 205, labelY: 236 },
+    { from: "submitted", to: "more-info", type: "alt", label: "needs details", labelX: 188, labelY: 210 },
+    { from: "more-info", to: "submitted", type: "alt", label: "resubmit", labelX: 310, labelY: 220 },
+    { from: "approved", to: "in-development", type: "normal", label: "start build", labelX: 405, labelY: 236 },
+    { from: "in-development", to: "self-qa", type: "normal", label: "ready to test", labelX: 615, labelY: 236 },
+    { from: "self-qa", to: "in-development", type: "alt", label: "fix issues", labelX: 615, labelY: 374 },
+    { from: "self-qa", to: "self-qa-complete", type: "normal", label: "QA passes", labelX: 835, labelY: 236 },
+    { from: "self-qa-complete", to: "completed", type: "normal", label: "complete", labelX: 1065, labelY: 236 },
+    { from: "completed", to: "quarterly-qa", type: "normal", label: "scheduled review", labelX: 1088, labelY: 386 },
+    { from: "quarterly-qa", to: "in-development", type: "alt", label: "updates needed", labelX: 720, labelY: 414 },
+    { from: "quarterly-qa", to: "quarterly-qa-complete", type: "normal", label: "QA passes", labelX: 1065, labelY: 416 },
+    { from: "quarterly-qa-complete", to: "completed", type: "normal", label: "return", labelX: 1210, labelY: 386 }
+  ];
+  var wmsStatusGraphNodeMap = wmsStatusGraphStatuses.reduce(function (map, status) {
+    map[status.id] = status;
+    return map;
+  }, {});
   var previousView = {
     mode: "hub",
     currentStep: 0,
@@ -1587,37 +1763,338 @@
     }, 180);
   }
 
-  function activateWmsStatus(button) {
-    var flow = button ? button.closest("[data-status-flow]") : null;
-    var rows;
-    var index;
-    var row;
+  function createWmsStatusSvgElement(name, attrs) {
+    var element = document.createElementNS("http://www.w3.org/2000/svg", name);
 
-    if (!flow) {
+    Object.keys(attrs || {}).forEach(function (key) {
+      element.setAttribute(key, attrs[key]);
+    });
+
+    return element;
+  }
+
+  function wmsStatusBoundaryPoint(box, toward) {
+    var dx = toward.x - box.x;
+    var dy = toward.y - box.y;
+    var scale = Math.min(Math.abs(wmsStatusNodeHalfWidth / (dx || 0.0001)), Math.abs(wmsStatusNodeHalfHeight / (dy || 0.0001)));
+
+    return { x: box.x + dx * scale, y: box.y + dy * scale };
+  }
+
+  function wmsStatusEdgePath(from, to, type) {
+    var start = wmsStatusBoundaryPoint(from, to);
+    var end = wmsStatusBoundaryPoint(to, from);
+    var dx;
+    var dy;
+    var curve;
+    var mx;
+    var my;
+    var nx;
+    var ny;
+
+    if (type === "alt") {
+      dx = end.x - start.x;
+      dy = end.y - start.y;
+      curve = Math.max(80, Math.hypot(dx, dy) * 0.35);
+      mx = (start.x + end.x) / 2;
+      my = (start.y + end.y) / 2;
+      nx = -dy / Math.max(1, Math.hypot(dx, dy));
+      ny = dx / Math.max(1, Math.hypot(dx, dy));
+      return "M " + start.x + " " + start.y + " Q " + (mx + nx * curve) + " " + (my + ny * curve) + " " + end.x + " " + end.y;
+    }
+
+    return "M " + start.x + " " + start.y + " L " + end.x + " " + end.y;
+  }
+
+  function wmsStatusTransitionMidpoint(transition) {
+    var from = wmsStatusGraphNodeMap[transition.from];
+    var to = wmsStatusGraphNodeMap[transition.to];
+
+    if (Number.isFinite(transition.labelX) && Number.isFinite(transition.labelY)) {
+      return { x: transition.labelX, y: transition.labelY };
+    }
+
+    return {
+      x: (from.x + to.x) / 2,
+      y: (from.y + to.y) / 2 - (transition.type === "alt" ? 18 : 10)
+    };
+  }
+
+  function wmsStatusEdgeLabelWidth(label) {
+    return Math.max(54, Math.min(128, String(label || "").length * 7 + 18));
+  }
+
+  function setWmsStatusGraphViewBox(svg, box) {
+    var target = box || wmsStatusGraphViewBox;
+
+    svg.setAttribute("viewBox", target.x + " " + target.y + " " + target.width + " " + target.height);
+  }
+
+  function defineWmsStatusMarkers(svg, graphId) {
+    var defs = createWmsStatusSvgElement("defs");
+    var normalMarker = createWmsStatusSvgElement("marker", {
+      id: graphId + "-arrow-normal",
+      viewBox: "0 -5 10 10",
+      refX: "10",
+      refY: "0",
+      markerWidth: "7",
+      markerHeight: "7",
+      orient: "auto"
+    });
+    var altMarker = createWmsStatusSvgElement("marker", {
+      id: graphId + "-arrow-alt",
+      viewBox: "0 -5 10 10",
+      refX: "10",
+      refY: "0",
+      markerWidth: "7",
+      markerHeight: "7",
+      orient: "auto"
+    });
+
+    normalMarker.appendChild(createWmsStatusSvgElement("path", { d: "M0,-5L10,0L0,5", fill: "#7c8794" }));
+    altMarker.appendChild(createWmsStatusSvgElement("path", { d: "M0,-5L10,0L0,5", fill: "#a16207" }));
+    defs.appendChild(normalMarker);
+    defs.appendChild(altMarker);
+    svg.appendChild(defs);
+  }
+
+  function renderWmsStatusList(list, items) {
+    if (!list) {
       return;
     }
 
-    rows = Array.from(flow.querySelectorAll(".wms-status-csv code")).slice(1).map(function (node) {
-      var parts = node.textContent.split(",");
-      return {
-        status: (parts[0] || "").trim(),
-        owner: (parts[1] || "").trim(),
-        description: parts.slice(2).join(",").trim()
-      };
+    list.innerHTML = "";
+    items.forEach(function (item) {
+      var li = document.createElement("li");
+      li.textContent = item;
+      list.appendChild(li);
     });
-    index = Number(button.getAttribute("data-status-index") || "0");
-    row = rows[index] || rows[0];
+  }
 
-    flow.querySelectorAll(".wms-status-button").forEach(function (candidate) {
-      var isActive = candidate === button;
-      candidate.classList.toggle("is-active", isActive);
-      candidate.setAttribute("aria-selected", isActive ? "true" : "false");
+  function updateWmsStatusGraphDetails(graph, status) {
+    var outgoing = wmsStatusGraphTransitions.filter(function (transition) {
+      return transition.from === status.id;
+    });
+    var title = graph.querySelector("[data-wms-status-title]");
+    var group = graph.querySelector("[data-wms-status-group]");
+    var responsible = graph.querySelector("[data-wms-status-responsible]");
+    var meaning = graph.querySelector("[data-wms-status-meaning]");
+    var nextStep = graph.querySelector("[data-wms-status-next]");
+    var checklist = graph.querySelector("[data-wms-status-checklist]");
+    var transitionList = graph.querySelector("[data-wms-status-transitions]");
+
+    if (title) {
+      title.textContent = status.label;
+    }
+    if (group) {
+      group.textContent = status.group;
+    }
+    if (responsible) {
+      responsible.textContent = status.responsible;
+    }
+    if (meaning) {
+      meaning.textContent = status.meaning;
+    }
+    if (nextStep) {
+      nextStep.textContent = status.nextStep;
+    }
+
+    renderWmsStatusList(checklist, status.checks);
+    renderWmsStatusList(transitionList, outgoing.length ? outgoing.map(function (transition) {
+      return wmsStatusGraphNodeMap[transition.to].label + ": " + transition.label;
+    }) : ["No outgoing transition configured."]);
+  }
+
+  function applyWmsStatusGraphHighlights(graph) {
+    var selectedStatusId = graph.getAttribute("data-selected-status") || "";
+    var highlightedPath = (graph.getAttribute("data-highlighted-path") || "").split(",").filter(Boolean);
+    var connected = {};
+    var pathNodes = {};
+    var pathEdges = {};
+
+    if (selectedStatusId) {
+      connected[selectedStatusId] = true;
+      wmsStatusGraphTransitions.forEach(function (transition) {
+        if (transition.from === selectedStatusId || transition.to === selectedStatusId) {
+          connected[transition.from] = true;
+          connected[transition.to] = true;
+        }
+      });
+    }
+
+    highlightedPath.forEach(function (id, index) {
+      pathNodes[id] = true;
+      if (highlightedPath[index + 1]) {
+        pathEdges[id + "->" + highlightedPath[index + 1]] = true;
+      }
     });
 
-    flow.querySelector("#wmsStatusOwner").textContent = row.owner;
-    flow.querySelector("#wmsStatusTitle").textContent = row.status;
-    flow.querySelector("#wmsStatusDescription").textContent = row.description;
-    setLiveMessage(row.status + " status selected.");
+    graph.querySelectorAll(".wms-status-node").forEach(function (node) {
+      var id = node.getAttribute("data-status-id");
+      var isSelected = id === selectedStatusId || !!pathNodes[id];
+      var shouldDim = selectedStatusId ? !connected[id] : highlightedPath.length ? !pathNodes[id] : false;
+
+      node.classList.toggle("is-selected", isSelected);
+      node.classList.toggle("is-dimmed", shouldDim);
+    });
+
+    graph.querySelectorAll(".wms-status-edge").forEach(function (edge) {
+      var edgeKey = edge.getAttribute("data-from") + "->" + edge.getAttribute("data-to");
+      var selectedEdge = selectedStatusId && (edge.getAttribute("data-from") === selectedStatusId || edge.getAttribute("data-to") === selectedStatusId);
+      var pathEdge = !!pathEdges[edgeKey];
+      var shouldDim = selectedStatusId ? !selectedEdge : highlightedPath.length ? !pathEdge : false;
+
+      edge.classList.toggle("is-dimmed", shouldDim);
+      edge.classList.toggle("is-selected", selectedEdge || pathEdge);
+    });
+
+    graph.querySelectorAll(".wms-status-edge-label, .wms-status-edge-label-bg").forEach(function (label) {
+      var edgeKey = label.getAttribute("data-from") + "->" + label.getAttribute("data-to");
+      var selectedEdge = selectedStatusId && (label.getAttribute("data-from") === selectedStatusId || label.getAttribute("data-to") === selectedStatusId);
+      var pathEdge = !!pathEdges[edgeKey];
+      var shouldDim = selectedStatusId ? !selectedEdge : highlightedPath.length ? !pathEdge : false;
+
+      label.classList.toggle("is-dimmed", shouldDim);
+    });
+  }
+
+  function selectWmsStatusGraphNode(graph, id) {
+    var status = wmsStatusGraphNodeMap[id];
+
+    if (!graph || !status) {
+      return;
+    }
+
+    graph.setAttribute("data-selected-status", id);
+    graph.removeAttribute("data-highlighted-path");
+    updateWmsStatusGraphDetails(graph, status);
+    applyWmsStatusGraphHighlights(graph);
+    setLiveMessage(status.label + " status selected.");
+  }
+
+  function highlightWmsStatusGraphPath(graph, ids, label) {
+    graph.removeAttribute("data-selected-status");
+    graph.setAttribute("data-highlighted-path", ids.join(","));
+    updateWmsStatusGraphDetails(graph, wmsStatusGraphNodeMap[ids[0]] || wmsStatusGraphStatuses[0]);
+    applyWmsStatusGraphHighlights(graph);
+    setLiveMessage((label || "Status path") + " highlighted.");
+  }
+
+  function resetWmsStatusGraph(graph) {
+    graph.removeAttribute("data-highlighted-path");
+    selectWmsStatusGraphNode(graph, graph.getAttribute("data-default-status") || "submitted");
+  }
+
+  function fitWmsStatusGraph(graph) {
+    var svg = graph.querySelector("[data-wms-status-svg]");
+    var xs = wmsStatusGraphStatuses.map(function (status) { return status.x; });
+    var ys = wmsStatusGraphStatuses.map(function (status) { return status.y; });
+    var minX = Math.min.apply(Math, xs) - wmsStatusNodeHalfWidth - wmsStatusGraphFitGutter;
+    var maxX = Math.max.apply(Math, xs) + wmsStatusNodeHalfWidth + wmsStatusGraphFitGutter;
+    var minY = Math.min.apply(Math, ys) - wmsStatusNodeHalfHeight - wmsStatusGraphFitGutter;
+    var maxY = Math.max.apply(Math, ys) + wmsStatusNodeHalfHeight + wmsStatusGraphFitGutter;
+
+    if (svg) {
+      setWmsStatusGraphViewBox(svg, { x: minX, y: minY, width: maxX - minX, height: maxY - minY });
+    }
+
+    setLiveMessage("Status graph fitted to visible nodes.");
+  }
+
+  function renderWmsStatusGraph(graph, index) {
+    var svg = graph.querySelector("[data-wms-status-svg]");
+    var graphId = "wms-status-graph-" + index;
+    var edgeLayer = createWmsStatusSvgElement("g", { class: "wms-status-edges" });
+    var labelLayer = createWmsStatusSvgElement("g", { class: "wms-status-edge-labels" });
+    var nodeLayer = createWmsStatusSvgElement("g", { class: "wms-status-nodes" });
+
+    if (!svg) {
+      return;
+    }
+
+    svg.innerHTML = "";
+    setWmsStatusGraphViewBox(svg);
+    defineWmsStatusMarkers(svg, graphId);
+    svg.appendChild(createWmsStatusSvgElement("title", { id: graphId + "-title" })).textContent = "LiveLabs workshop status workflow graph";
+    svg.appendChild(createWmsStatusSvgElement("desc", { id: graphId + "-desc" })).textContent = "A clickable graph showing submitted, approval, development, self QA, completed, and quarterly QA statuses.";
+    svg.setAttribute("aria-labelledby", graphId + "-title " + graphId + "-desc");
+
+    wmsStatusGraphTransitions.forEach(function (transition) {
+      var from = wmsStatusGraphNodeMap[transition.from];
+      var to = wmsStatusGraphNodeMap[transition.to];
+      var path = createWmsStatusSvgElement("path", {
+        class: "wms-status-edge" + (transition.type === "alt" ? " is-return-path" : ""),
+        d: wmsStatusEdgePath(from, to, transition.type),
+        "data-from": transition.from,
+        "data-to": transition.to,
+        "marker-end": "url(#" + graphId + (transition.type === "alt" ? "-arrow-alt" : "-arrow-normal") + ")"
+      });
+      var midpoint = wmsStatusTransitionMidpoint(transition);
+      var labelWidth = wmsStatusEdgeLabelWidth(transition.label);
+      var labelBackground = createWmsStatusSvgElement("rect", {
+        class: "wms-status-edge-label-bg",
+        x: midpoint.x - labelWidth / 2,
+        y: midpoint.y - 12,
+        width: labelWidth,
+        height: 24,
+        rx: 8,
+        "data-from": transition.from,
+        "data-to": transition.to
+      });
+      var text = createWmsStatusSvgElement("text", {
+        class: "wms-status-edge-label",
+        x: midpoint.x,
+        y: midpoint.y,
+        "text-anchor": "middle",
+        "dominant-baseline": "middle",
+        "data-from": transition.from,
+        "data-to": transition.to
+      });
+
+      text.textContent = transition.label;
+      edgeLayer.appendChild(path);
+      labelLayer.appendChild(labelBackground);
+      labelLayer.appendChild(text);
+    });
+
+    wmsStatusGraphStatuses.forEach(function (status) {
+      var group = createWmsStatusSvgElement("g", {
+        class: "wms-status-node",
+        tabindex: "0",
+        role: "button",
+        "aria-label": status.label + " status",
+        transform: "translate(" + status.x + "," + status.y + ")",
+        "data-status-id": status.id
+      });
+      var rect = createWmsStatusSvgElement("rect", {
+        x: -wmsStatusNodeHalfWidth,
+        y: -wmsStatusNodeHalfHeight,
+        width: wmsStatusNodeHalfWidth * 2,
+        height: wmsStatusNodeHalfHeight * 2,
+        rx: "8",
+        fill: status.color
+      });
+      var label = createWmsStatusSvgElement("text", { x: "0", y: "-5", "text-anchor": "middle" });
+      var subtext = createWmsStatusSvgElement("text", { x: "0", y: "16", "text-anchor": "middle", class: "wms-status-node-subtext" });
+
+      label.textContent = status.label;
+      subtext.textContent = status.group;
+      group.appendChild(rect);
+      group.appendChild(label);
+      group.appendChild(subtext);
+      nodeLayer.appendChild(group);
+    });
+
+    svg.appendChild(edgeLayer);
+    svg.appendChild(labelLayer);
+    svg.appendChild(nodeLayer);
+    selectWmsStatusGraphNode(graph, graph.getAttribute("data-default-status") || "submitted");
+  }
+
+  function initWmsStatusGraphs() {
+    document.querySelectorAll("[data-wms-status-graph]").forEach(function (graph, index) {
+      renderWmsStatusGraph(graph, index + 1);
+    });
   }
 
   function syncMarkdownSnippetSummary() {
@@ -3545,7 +4022,8 @@
     var copyTextButton = event.target.closest("[data-copy-text]");
     var tagButton = event.target.closest("[data-tag]");
     var searchOpenButton = event.target.closest("[data-search-open]");
-    var wmsStatusButton = event.target.closest(".wms-status-button");
+    var wmsStatusNode = event.target.closest(".wms-status-node");
+    var wmsStatusAction = event.target.closest("[data-wms-status-action]");
     var installCard = event.target.closest("[data-install-card]");
     var isPrimaryNav = modeButton && !!modeButton.closest(".nav-group-all");
 
@@ -3670,8 +4148,24 @@
       openSearchResult(searchOpenButton.getAttribute("data-search-open"));
     }
 
-    if (wmsStatusButton) {
-      activateWmsStatus(wmsStatusButton);
+    if (wmsStatusNode) {
+      selectWmsStatusGraphNode(wmsStatusNode.closest("[data-wms-status-graph]"), wmsStatusNode.getAttribute("data-status-id"));
+      return;
+    }
+
+    if (wmsStatusAction) {
+      var graph = wmsStatusAction.closest("[data-wms-status-graph]");
+      var action = wmsStatusAction.getAttribute("data-wms-status-action");
+
+      if (action === "main-path") {
+        highlightWmsStatusGraphPath(graph, ["submitted", "approved", "in-development", "self-qa", "self-qa-complete", "completed"], "Main path");
+      } else if (action === "qa-cycle") {
+        highlightWmsStatusGraphPath(graph, ["completed", "quarterly-qa", "quarterly-qa-complete", "completed"], "QA cycle");
+      } else if (action === "fit") {
+        fitWmsStatusGraph(graph);
+      } else {
+        resetWmsStatusGraph(graph);
+      }
       return;
     }
   });
@@ -3687,6 +4181,12 @@
     if ((event.key === "Enter" || event.key === " ") && event.target && event.target.closest && event.target.closest("figure[data-expandable=\"true\"]")) {
       event.preventDefault();
       openImageLightbox(event.target.closest("figure[data-expandable=\"true\"]"));
+      return;
+    }
+
+    if ((event.key === "Enter" || event.key === " ") && event.target && event.target.closest && event.target.closest(".wms-status-node")) {
+      event.preventDefault();
+      selectWmsStatusGraphNode(event.target.closest("[data-wms-status-graph]"), event.target.closest(".wms-status-node").getAttribute("data-status-id"));
     }
   }, true);
 
@@ -3844,6 +4344,7 @@
 
   hydrateVideoCards(document);
   decorateExpandableMedia(document);
+  initWmsStatusGraphs();
   updateNav();
   updateNavSearch();
   updateBeginnerUI();

--- a/new-author-guide/index.html
+++ b/new-author-guide/index.html
@@ -5560,32 +5560,56 @@
                       <div class="step-block-header">
                         <div class="panel-kicker">Status flow</div>
                         <h3>Understand the handoff path before you build</h3>
-                        <p>The status flow below is the process map. Use these WMS states to understand when to wait for review, when to begin heavier GitHub work, when to complete Quality Assurance, and when the workshop is ready for publishing.</p>
+                        <p>The graph below is the process map. Use these WMS states to understand when to wait for review, when to begin heavier GitHub work, when to complete Quality Assurance, and when the workshop moves into publication and later maintenance.</p>
                       </div>
-                      <div class="wms-status-flow" data-status-flow>
-                        <div class="wms-status-csv" aria-label="WMS status flow source data">
-                          <code>Status,Owner,Meaning</code>
-                          <code>Submitted,Council,The council receives the request and starts its first review pass.</code>
-                          <code>More Info Needed,Workshop team,Answer council questions in WMS and improve the request until the use case is clear.</code>
-                          <code>Approved,Workshop team,Begin heavier GitHub work only after the initial WMS review gate clears.</code>
-                          <code>In Development,Workshop team,Use this when real authoring starts in GitHub and the preview path exists.</code>
-                          <code>Self QA,Workshop team,Run end-to-end testing and complete the Self Quality Assurance checklist.</code>
-                          <code>Self QA Complete,Stakeholders,Stakeholders verify the saved checklist and workshop preview.</code>
-                          <code>Completed,LiveLabs publishing,The verified workshop is ready for final publishing handling.</code>
+                      <div class="wms-status-graph" data-wms-status-graph data-default-status="submitted">
+                        <div class="wms-status-graph-toolbar" aria-label="Status graph controls">
+                          <div class="wms-status-legend" aria-label="Status graph legend">
+                            <span class="wms-status-legend-pill">Normal progression</span>
+                            <span class="wms-status-legend-pill is-return-path">Rework or return path</span>
+                            <span class="wms-status-legend-pill is-selected">Selected status</span>
+                          </div>
+                          <div class="wms-status-actions">
+                            <button type="button" class="wms-status-action" data-wms-status-action="reset">Reset</button>
+                            <button type="button" class="wms-status-action" data-wms-status-action="main-path">Main path</button>
+                            <button type="button" class="wms-status-action" data-wms-status-action="qa-cycle">QA cycle</button>
+                            <button type="button" class="wms-status-action" data-wms-status-action="fit">Fit graph</button>
+                          </div>
                         </div>
-                        <div class="wms-status-buttons" role="tablist" aria-label="WMS status states">
-                          <button type="button" class="wms-status-button is-active" data-status-index="0" role="tab" aria-selected="true">Submitted</button>
-                          <button type="button" class="wms-status-button" data-status-index="1" role="tab" aria-selected="false">More Info Needed</button>
-                          <button type="button" class="wms-status-button" data-status-index="2" role="tab" aria-selected="false">Approved</button>
-                          <button type="button" class="wms-status-button" data-status-index="3" role="tab" aria-selected="false">In Development</button>
-                          <button type="button" class="wms-status-button" data-status-index="4" role="tab" aria-selected="false">Self QA</button>
-                          <button type="button" class="wms-status-button" data-status-index="5" role="tab" aria-selected="false">Self QA Complete</button>
-                          <button type="button" class="wms-status-button" data-status-index="6" role="tab" aria-selected="false">Completed</button>
-                        </div>
-                        <div class="wms-status-detail" role="tabpanel" aria-live="polite">
-                          <span class="detail-field-label" id="wmsStatusOwner">Council</span>
-                          <h4 id="wmsStatusTitle">Submitted</h4>
-                          <p id="wmsStatusDescription">The council receives the request and starts its first review pass.</p>
+                        <div class="wms-status-graph-layout">
+                          <div class="wms-status-graph-stage">
+                            <svg class="wms-status-svg" data-wms-status-svg role="img"></svg>
+                          </div>
+                          <aside class="wms-status-detail" aria-live="polite">
+                            <div class="wms-status-detail-header">
+                              <span class="detail-field-label" data-wms-status-group>Intake</span>
+                              <h4 data-wms-status-title>Submitted</h4>
+                            </div>
+                            <div class="wms-status-detail-block">
+                              <strong>Meaning</strong>
+                              <p data-wms-status-meaning>The workshop has been submitted for initial review.</p>
+                            </div>
+                            <div class="wms-status-detail-block">
+                              <strong>Responsible</strong>
+                              <p data-wms-status-responsible>Workshop author / submitter</p>
+                            </div>
+                            <div class="wms-status-detail-block">
+                              <strong>Next step</strong>
+                              <p data-wms-status-next>The reviewer validates whether the submitted information is sufficient.</p>
+                            </div>
+                            <div class="wms-status-detail-block">
+                              <strong>QA / completion checks</strong>
+                              <ul data-wms-status-checklist>
+                                <li>Workshop details are present.</li>
+                              </ul>
+                            </div>
+                            <div class="wms-status-detail-block">
+                              <strong>Possible transitions</strong>
+                              <ul data-wms-status-transitions>
+                                <li>Approved: review passes</li>
+                              </ul>
+                            </div>
+                          </aside>
                         </div>
                       </div>
                     </section>
@@ -6560,11 +6584,11 @@ Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="./assets/js/guide-content.js?v=20260703-cheatsheet-refresh"></script>
+  <script src="./assets/js/guide-content.js"></script>
   <script src="./assets/js/workshop-generator.js"></script>
   <script src="./assets/js/redwood-video-player.js"></script>
   <script src="./assets/js/shared-side-nav.js?v=20260529-shared-nav-v2"></script>
-  <script src="./assets/js/author-guide-app.js?v=20260703-cheatsheet-refresh"></script>
+  <script src="./assets/js/author-guide-app.js?v=20260529-nav-search-v2"></script>
   <script src="./assets/js/shared-footer.js?v=20260516-followup"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replaces the Quickstart Status flow tabs with the implemented interactive WMS status graph.
- Adjusts graph sizing and transition label placement so cards and descriptions stay within the container.
- Keeps the change scoped to the new author guide assets and page hook.

## Validation
- node --check new-author-guide/assets/js/author-guide-app.js
- node --check new-author-guide/assets/js/guide-content.js
- Local preview verified at http://127.0.0.1:4190/#quickstart

Note: direct push to main was blocked by branch protection, so this PR is required for GitHub Pages to receive the change.